### PR TITLE
refactor tasks data fetching

### DIFF
--- a/app/tasks/page.tsx
+++ b/app/tasks/page.tsx
@@ -4,6 +4,7 @@ import { DashboardSkeleton } from '@/components/dashboard/dashboard-skeleton'
 import { redirect } from 'next/navigation'
 import { Suspense } from 'react'
 import type { Metadata } from 'next'
+import { getUserTasks, getProjects } from '@/lib/task-service'
 
 export const metadata: Metadata = {
   title: 'Tasks | Ultimate Todo App',
@@ -21,49 +22,21 @@ async function TasksContent() {
   }
 
   try {
-    // Fetch tasks with their projects
-    const { data: tasks, error: tasksError } = await supabase
-      .from('tasks')
-      .select(`
-        *,
-        project:projects(*)
-      `)
-      .eq('user_id', user.id)
-      .order('created_at', { ascending: false })
-
-    if (tasksError) {
-      console.error('Error fetching tasks:', tasksError)
-      throw tasksError
-    }
-
-    // Transform tasks to include project details
-    const transformedTasks = tasks.map(task => ({
-      ...task,
-      project_details: task.project
-    }))
-
-     // Fetch projects
-     const { data: projects, error: projectsError } = await supabase
-     .from('projects')
-     .select('*')
-     .order('name')
-
-   if (projectsError) {
-     console.error('Error fetching projects:', projectsError)
-     throw projectsError
-   }
+    const [tasks, projects] = await Promise.all([
+      getUserTasks(user.id),
+      getProjects(user.id)
+    ])
 
     return (
       <div className="space-y-8">
-        <TaskList 
-          initialTasks={transformedTasks || []}
+        <TaskList
+          initialTasks={tasks}
           userId={user.id}
-          projects={projects || []}
+          projects={projects}
         />
       </div>
     )
   } catch (error) {
-    console.error('Error in TasksContent:', error)
     throw error
   }
 }

--- a/lib/task-service.ts
+++ b/lib/task-service.ts
@@ -1,0 +1,52 @@
+import { createClient } from '@/lib/supabase-server'
+import type { Task, Project } from '@/lib/types'
+
+const MAX_RETRIES = 3
+
+async function withRetry<T>(operation: () => Promise<T>, context: string): Promise<T> {
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      return await operation()
+    } catch (error) {
+      console.error(`${context} attempt ${attempt} failed:`, error)
+      if (attempt === MAX_RETRIES) throw error
+    }
+  }
+  throw new Error(`Failed to ${context}`)
+}
+
+export async function getUserTasks(userId: string): Promise<Task[]> {
+  const supabase = await createClient()
+  return withRetry(async () => {
+    const { data, error } = await supabase
+      .from('tasks')
+      .select(`
+        *,
+        project:projects(*)
+      `)
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+
+    if (error) throw error
+
+    return (data || []).map(task => ({
+      ...task,
+      project_details: (task as any).project
+    })) as Task[]
+  }, 'fetch user tasks')
+}
+
+export async function getProjects(userId: string): Promise<Project[]> {
+  const supabase = await createClient()
+  return withRetry(async () => {
+    const { data, error } = await supabase
+      .from('projects')
+      .select('*')
+      .eq('user_id', userId)
+      .order('name')
+
+    if (error) throw error
+    return (data || []) as Project[]
+  }, 'fetch projects')
+}
+


### PR DESCRIPTION
## Summary
- move task and project fetching logic to new `task-service`
- centralize retries and logging in service helpers
- update tasks page to consume service functions

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6897c4c4abc8832da475262537bbac84