### PR TITLE
Handle invite API responses

### DIFF
--- a/components/teams/TeamManager.tsx
+++ b/components/teams/TeamManager.tsx
@@ -3,6 +3,7 @@ import React, {useState} from 'react';
 import {Button} from '@/components/ui/button';
 import {Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger} from '@/components/ui/dialog';
 import {Input} from '@/components/ui/input';
+import {useToast} from '@/components/ui/use-toast';
 import {inviteUserToTeam} from '@/features/inviteUser';
 
 interface TeamManagerProps {
@@ -11,11 +12,33 @@ interface TeamManagerProps {
 
 const TeamManager: React.FC<TeamManagerProps> = ({teamId}) => {
     const [email, setEmail] = useState('');
+    const {toast} = useToast();
 
     const handleInvite = async (e: React.FormEvent) => {
         e.preventDefault();
-        await inviteUserToTeam(teamId, email);
-        setEmail('');
+        try {
+            const result = await inviteUserToTeam(teamId, email);
+            if (result.success) {
+                toast({
+                    title: 'Invitation sent',
+                    description: result.message,
+                });
+                setEmail('');
+            } else {
+                toast({
+                    title: 'Error',
+                    description: result.message,
+                    variant: 'destructive',
+                });
+            }
+        } catch (error) {
+            const message = error instanceof Error ? error.message : 'Failed to send invitation';
+            toast({
+                title: 'Error',
+                description: message,
+                variant: 'destructive',
+            });
+        }
     };
 
     return (

--- a/features/inviteUser.ts
+++ b/features/inviteUser.ts
@@ -1,5 +1,9 @@
+export interface InviteUserResult {
+    success: boolean;
+    message: string;
+}
 
-export const inviteUserToTeam = async (teamId: number, email: string) => {
+export const inviteUserToTeam = async (teamId: number, email: string): Promise<InviteUserResult> => {
     const response = await fetch(`/api/teams/${teamId}/invite`, {
         method: 'POST',
         headers: {
@@ -7,4 +11,19 @@ export const inviteUserToTeam = async (teamId: number, email: string) => {
         },
         body: JSON.stringify({ email }),
     });
+
+    let data: any = null;
+    try {
+        data = await response.json();
+    } catch (error) {
+        // Ignore JSON parse errors and use default messages
+    }
+
+    if (!response.ok) {
+        const message = data?.error || data?.message || 'Failed to send invitation';
+        return { success: false, message };
+    }
+
+    const message = data?.message || 'Invitation sent successfully';
+    return { success: true, message };
 }


### PR DESCRIPTION
## Summary
- parse invite API responses and return structured success/error result
- surface invite outcome to TeamManager UI with toasts

## Testing
- `pnpm lint`
- `pnpm run test` *(fails: Missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_6897c4c2f90c832d8ec74fd206132856