### PR TITLE
feat: add offline caching and push notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,12 @@ The app implements an agentic approach to task management:
    - Adjusts timing based on task proximity
    - Considers user's working hours
 
+## Offline & Notifications
+
+- Service worker powered by Workbox caches assets for offline support.
+- Push notifications use the Notifications API with subscriptions sent to `/api/subscribe`.
+- Set `NEXT_PUBLIC_VAPID_PUBLIC_KEY` to enable browser push messaging.
+
 ## Contributing
 
 We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for details.

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(req: Request) {
+  const subscription = await req.json();
+
+  // In a real application you would store the subscription in your database
+  console.log('Received push subscription', subscription);
+
+  return NextResponse.json({ received: true });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,6 +25,38 @@ export default async function RootLayout({
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
 
+  const swRegisterScript = `
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', async () => {
+    try {
+      const registration = await navigator.serviceWorker.register('/sw.js');
+      if ('Notification' in window) {
+        const permission = await Notification.requestPermission();
+        if (permission === 'granted') {
+          const subscription = await registration.pushManager.subscribe({
+            userVisibleOnly: true,${process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY ? `
+            applicationServerKey: urlBase64ToUint8Array('${process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY}'),` : ''}
+          });
+          await fetch('/api/subscribe', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(subscription)
+          });
+        }
+      }
+    } catch (err) {
+      console.error('Service worker registration failed', err);
+    }
+  });
+}
+function urlBase64ToUint8Array(base64String) {
+  const padding = '='.repeat((4 - base64String.length % 4) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const rawData = atob(base64);
+  return Uint8Array.from([...rawData].map((char) => char.charCodeAt(0)));
+}
+`
+
   return (
     <html lang="en" className={cn(
       "min-h-screen bg-background font-sans antialiased",
@@ -37,6 +69,7 @@ export default async function RootLayout({
             <Toaster position="bottom-right" richColors closeButton />
           </ClientWrapper>
         </SessionProvider>
+        <script dangerouslySetInnerHTML={{ __html: swRegisterScript }} />
       </body>
     </html>
   );

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,29 @@
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.5.4/workbox-sw.js');
+
+workbox.setConfig({ debug: false });
+
+// Precache assets built by Next.js
+workbox.precaching.precacheAndRoute(self.__WB_MANIFEST || []);
+
+// Cache common assets and pages using a stale-while-revalidate strategy
+workbox.routing.registerRoute(
+  ({ request }) => ['style', 'script', 'worker', 'document', 'image', 'font'].includes(request.destination),
+  new workbox.strategies.StaleWhileRevalidate({
+    cacheName: 'asset-cache',
+  })
+);
+
+self.addEventListener('push', event => {
+  const data = event.data?.json() ?? {};
+  event.waitUntil(
+    self.registration.showNotification(data.title || 'Notification', {
+      body: data.body || '',
+      icon: '/logo.png',
+    })
+  );
+});
+
+self.addEventListener('notificationclick', event => {
+  event.notification.close();
+  event.waitUntil(clients.openWindow('/'));
+});


### PR DESCRIPTION
## Summary
- cache assets offline with a Workbox service worker
- register service worker and push subscription in the app layout
- expose `/api/subscribe` endpoint for push notification subscriptions

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6897c4b43384832d823ae7ba9da66cb5