### PR TITLE
Validate Supabase environment variables with zod

### DIFF
--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod'
+
+const envSchema = z.object({
+  NEXT_PUBLIC_SUPABASE_URL: z
+    .string({ required_error: 'NEXT_PUBLIC_SUPABASE_URL is required' })
+    .url('NEXT_PUBLIC_SUPABASE_URL must be a valid URL'),
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string({
+    required_error: 'NEXT_PUBLIC_SUPABASE_ANON_KEY is required'
+  })
+})
+
+const envResult = envSchema.safeParse({
+  NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+})
+
+if (!envResult.success) {
+  const missing = Object.entries(envResult.error.flatten().fieldErrors)
+    .map(([key, value]) => `${key}${value ? `: ${value.join(', ')}` : ''}`)
+    .join('\n')
+  const message = `Missing or invalid environment variables:\n${missing}`
+  if (process.env.NODE_ENV !== 'production') {
+    throw new Error(message)
+  } else {
+    console.error(message)
+  }
+}
+
+export const env = envResult.success
+  ? envResult.data
+  : ({} as z.infer<typeof envSchema>)
+

--- a/lib/supabase-client.ts
+++ b/lib/supabase-client.ts
@@ -1,5 +1,6 @@
 import { createBrowserClient } from '@supabase/ssr'
 import type { Database } from './database.types'
+import { env } from './env'
 
 /**
  * Creates a new Supabase browser client instance
@@ -20,8 +21,8 @@ import type { Database } from './database.types'
  */
 export const createClient = () => {
   return createBrowserClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    env.NEXT_PUBLIC_SUPABASE_URL,
+    env.NEXT_PUBLIC_SUPABASE_ANON_KEY
   )
 }
 
@@ -31,4 +32,4 @@ export const createClient = () => {
  * This is a singleton instance that can be imported and used
  * throughout the application for Supabase operations.
  */
-export const supabase = createClient() 
+export const supabase = createClient()


### PR DESCRIPTION
## Summary
- add `lib/env.ts` with zod-based parsing for Supabase env vars
- use validated env vars in `supabase-client`

## Testing
- `pnpm lint`
- `npm test` (fails: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_e_6897c4b35878832da6a6f7654dbed556