### PR TITLE
Refactor email API with validation and builders

### DIFF
--- a/__tests__/email-builders.test.ts
+++ b/__tests__/email-builders.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { buildTeamInvitationEmail, buildTaskAssignmentEmail, buildDueReminderEmail } from '../lib/email';
+
+describe('email builders', () => {
+    it('builds team invitation email', () => {
+        const data = {
+            teamName: 'A-Team',
+            inviterName: 'Alice',
+            inviteLink: 'https://example.com/invite',
+            recipientEmail: 'bob@example.com'
+        };
+        const result = buildTeamInvitationEmail(data, 'alice@example.com');
+        expect(result.to).toBe('bob@example.com');
+        expect(result.subject).toBe('Invitation to join A-Team on Ultimate Todo App');
+        expect(result.replyTo).toBe('alice@example.com');
+        expect(result.html).toContain('Join A-Team on Ultimate Todo App');
+    });
+
+    it('builds task assignment email', () => {
+        const data = {
+            taskTitle: 'Task 1',
+            assignerName: 'Alice',
+            taskLink: 'https://example.com/task',
+            assigneeEmail: 'bob@example.com'
+        };
+        const result = buildTaskAssignmentEmail(data, 'alice@example.com');
+        expect(result.to).toBe('bob@example.com');
+        expect(result.subject).toBe('New Task Assignment: Task 1');
+        expect(result.replyTo).toBe('alice@example.com');
+        expect(result.html).toContain('Task 1');
+    });
+
+    it('builds task due reminder email', () => {
+        const data = {
+            taskTitle: 'Task 1',
+            dueDate: '2024-01-01',
+            taskLink: 'https://example.com/task',
+            userEmail: 'bob@example.com'
+        };
+        const result = buildDueReminderEmail(data);
+        expect(result.to).toBe('bob@example.com');
+        expect(result.subject).toBe('Task Due Reminder: Task 1');
+        expect(result.html).toContain('Task Due Reminder');
+    });
+});

--- a/__tests__/email-validation.test.ts
+++ b/__tests__/email-validation.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { emailSchema } from '../app/api/email/validation';
+
+describe('email validation', () => {
+    it('validates team invitation', () => {
+        const payload = {
+            type: 'team_invitation',
+            data: {
+                teamName: 'A-Team',
+                inviterName: 'Alice',
+                inviteLink: 'https://example.com/invite',
+                recipientEmail: 'bob@example.com'
+            }
+        };
+        expect(() => emailSchema.parse(payload)).not.toThrow();
+    });
+
+    it('rejects invalid task assignment', () => {
+        const payload = {
+            type: 'task_assignment',
+            data: {
+                taskTitle: 'Task 1',
+                assignerName: 'Alice',
+                taskLink: 'not-a-url',
+                assigneeEmail: 'bob@example.com'
+            }
+        };
+        const result = emailSchema.safeParse(payload);
+        expect(result.success).toBe(false);
+    });
+
+    it('validates task due reminder', () => {
+        const payload = {
+            type: 'task_due_reminder',
+            data: {
+                taskTitle: 'Task 1',
+                dueDate: '2024-01-01',
+                taskLink: 'https://example.com/task',
+                userEmail: 'bob@example.com'
+            }
+        };
+        expect(emailSchema.parse(payload)).toEqual(payload);
+    });
+});

--- a/app/api/email/route.ts
+++ b/app/api/email/route.ts
@@ -1,85 +1,12 @@
 import { NextResponse } from 'next/server';
-import { sendEmail, getInvitationEmailTemplate, getTaskAssignmentEmailTemplate, getTaskDueReminderTemplate } from '@/lib/email';
-import { createServerClient } from '@supabase/ssr';
-import { cookies } from 'next/headers';
-import { z } from 'zod';
-
-// Validation schemas
-const emailBaseSchema = z.object({
-    type: z.enum(['team_invitation', 'task_assignment', 'task_due_reminder']),
-});
-
-const teamInvitationSchema = emailBaseSchema.extend({
-    type: z.literal('team_invitation'),
-    data: z.object({
-        teamName: z.string(),
-        inviterName: z.string(),
-        inviteLink: z.string().url(),
-        recipientEmail: z.string().email(),
-    }),
-});
-
-const taskAssignmentSchema = emailBaseSchema.extend({
-    type: z.literal('task_assignment'),
-    data: z.object({
-        taskTitle: z.string(),
-        assignerName: z.string(),
-        taskLink: z.string().url(),
-        assigneeEmail: z.string().email(),
-    }),
-});
-
-const taskDueReminderSchema = emailBaseSchema.extend({
-    type: z.literal('task_due_reminder'),
-    data: z.object({
-        taskTitle: z.string(),
-        dueDate: z.string(),
-        taskLink: z.string().url(),
-        userEmail: z.string().email(),
-    }),
-});
-
-const emailSchema = z.discriminatedUnion('type', [
-    teamInvitationSchema,
-    taskAssignmentSchema,
-    taskDueReminderSchema,
-]);
+import { sendEmail, buildTeamInvitationEmail, buildTaskAssignmentEmail, buildDueReminderEmail } from '@/lib/email';
+import { emailSchema } from './validation';
+import { authenticateRequest } from '@/lib/api/authenticateRequest';
 
 export async function POST(req: Request) {
     try {
-        // Await the cookies() function as it returns a Promise in Next.js 15
-        const cookieStore = await cookies();
-        
-        // Verify authentication
-        const supabase = createServerClient(
-            process.env.NEXT_PUBLIC_SUPABASE_URL!,
-            process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-            {
-                cookies: {
-                    get(name: string) {
-                        const cookie = cookieStore.get(name);
-                        return cookie?.value;
-                    },
-                    set(name: string, value: string, options: any) {
-                        try {
-                            cookieStore.set({ name, value, ...options });
-                        } catch (error) {
-                            // Handle cookie errors in development
-                        }
-                    },
-                    remove(name: string, options: any) {
-                        try {
-                            cookieStore.delete({ name, ...options });
-                        } catch (error) {
-                            // Handle cookie errors in development
-                        }
-                    },
-                },
-            }
-        );
+        const { user, error: authError } = await authenticateRequest();
 
-        const { data: { user }, error: authError } = await supabase.auth.getUser();
-        
         if (authError || !user) {
             console.error('Authentication error:', authError);
             return NextResponse.json(
@@ -88,13 +15,12 @@ export async function POST(req: Request) {
             );
         }
 
-        // Parse and validate request body
         const body = await req.json();
         console.log('Received email request:', {
             ...body,
             data: {
                 ...body.data,
-                html: body.data.html ? '[HIDDEN]' : undefined
+                html: body.data?.html ? '[HIDDEN]' : undefined
             }
         });
 
@@ -103,9 +29,9 @@ export async function POST(req: Request) {
         if (!validationResult.success) {
             console.error('Validation error:', validationResult.error.format());
             return NextResponse.json(
-                { 
-                    error: 'Invalid request data', 
-                    details: validationResult.error.format() 
+                {
+                    error: 'Invalid request data',
+                    details: validationResult.error.format()
                 },
                 { status: 400 }
             );
@@ -115,37 +41,15 @@ export async function POST(req: Request) {
         let emailOptions;
 
         switch (type) {
-            case 'team_invitation': {
-                const { teamName, inviterName, inviteLink, recipientEmail } = data;
-                emailOptions = {
-                    to: recipientEmail,
-                    subject: `Invitation to join ${teamName} on Ultimate Todo App`,
-                    html: getInvitationEmailTemplate(teamName, inviterName, inviteLink),
-                    replyTo: user.email,
-                };
+            case 'team_invitation':
+                emailOptions = buildTeamInvitationEmail(data, user.email);
                 break;
-            }
-
-            case 'task_assignment': {
-                const { taskTitle, assignerName, taskLink, assigneeEmail } = data;
-                emailOptions = {
-                    to: assigneeEmail,
-                    subject: `New Task Assignment: ${taskTitle}`,
-                    html: getTaskAssignmentEmailTemplate(taskTitle, assignerName, taskLink),
-                    replyTo: user.email,
-                };
+            case 'task_assignment':
+                emailOptions = buildTaskAssignmentEmail(data, user.email);
                 break;
-            }
-
-            case 'task_due_reminder': {
-                const { taskTitle, dueDate, taskLink, userEmail } = data;
-                emailOptions = {
-                    to: userEmail,
-                    subject: `Task Due Reminder: ${taskTitle}`,
-                    html: getTaskDueReminderTemplate(taskTitle, dueDate, taskLink),
-                };
+            case 'task_due_reminder':
+                emailOptions = buildDueReminderEmail(data);
                 break;
-            }
         }
 
         console.log('Preparing to send email with options:', {
@@ -158,8 +62,8 @@ export async function POST(req: Request) {
         if (!result.success) {
             console.error('Failed to send email:', result.error);
             return NextResponse.json(
-                { 
-                    error: 'Failed to send email', 
+                {
+                    error: 'Failed to send email',
                     details: result.error,
                     emailOptions: {
                         ...emailOptions,
@@ -170,15 +74,15 @@ export async function POST(req: Request) {
             );
         }
 
-        return NextResponse.json({ 
-            success: true, 
+        return NextResponse.json({
+            success: true,
             data: result.data,
             message: 'Email sent successfully'
         });
     } catch (error) {
         console.error('Error in email API route:', error);
         return NextResponse.json(
-            { 
+            {
                 error: 'Internal server error',
                 message: error instanceof Error ? error.message : 'Unknown error occurred',
                 stack: process.env.NODE_ENV === 'development' ? error instanceof Error ? error.stack : undefined : undefined
@@ -186,4 +90,4 @@ export async function POST(req: Request) {
             { status: 500 }
         );
     }
-} 
+}

--- a/app/api/email/validation.ts
+++ b/app/api/email/validation.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+
+export const emailBaseSchema = z.object({
+    type: z.enum(['team_invitation', 'task_assignment', 'task_due_reminder']),
+});
+
+export const teamInvitationSchema = emailBaseSchema.extend({
+    type: z.literal('team_invitation'),
+    data: z.object({
+        teamName: z.string(),
+        inviterName: z.string(),
+        inviteLink: z.string().url(),
+        recipientEmail: z.string().email(),
+    }),
+});
+
+export const taskAssignmentSchema = emailBaseSchema.extend({
+    type: z.literal('task_assignment'),
+    data: z.object({
+        taskTitle: z.string(),
+        assignerName: z.string(),
+        taskLink: z.string().url(),
+        assigneeEmail: z.string().email(),
+    }),
+});
+
+export const taskDueReminderSchema = emailBaseSchema.extend({
+    type: z.literal('task_due_reminder'),
+    data: z.object({
+        taskTitle: z.string(),
+        dueDate: z.string(),
+        taskLink: z.string().url(),
+        userEmail: z.string().email(),
+    }),
+});
+
+export const emailSchema = z.discriminatedUnion('type', [
+    teamInvitationSchema,
+    taskAssignmentSchema,
+    taskDueReminderSchema,
+]);
+
+export type EmailRequest = z.infer<typeof emailSchema>;

--- a/lib/api/authenticateRequest.ts
+++ b/lib/api/authenticateRequest.ts
@@ -1,0 +1,37 @@
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+
+export async function authenticateRequest() {
+    const cookieStore = await cookies();
+
+    const supabase = createServerClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+        {
+            cookies: {
+                get(name: string) {
+                    const cookie = cookieStore.get(name);
+                    return cookie?.value;
+                },
+                set(name: string, value: string, options: any) {
+                    try {
+                        cookieStore.set({ name, value, ...options });
+                    } catch (error) {
+                        // Handle cookie errors in development
+                    }
+                },
+                remove(name: string, options: any) {
+                    try {
+                        cookieStore.delete({ name, ...options });
+                    } catch (error) {
+                        // Handle cookie errors in development
+                    }
+                },
+            },
+        }
+    );
+
+    const { data: { user }, error } = await supabase.auth.getUser();
+
+    return { user, error };
+}

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -1,8 +1,6 @@
 import { Resend } from 'resend';
 
-const resend = new Resend(process.env.RESEND_API_KEY);
-
-interface EmailOptions {
+export interface EmailOptions {
     to: string;
     subject: string;
     html: string;
@@ -14,6 +12,8 @@ export async function sendEmail({ to, subject, html, replyTo }: EmailOptions) {
         throw new Error('RESEND_API_KEY is not configured');
     }
 
+    const resend = new Resend(process.env.RESEND_API_KEY);
+
     if (!to || !subject || !html) {
         throw new Error('Missing required email parameters');
     }
@@ -22,7 +22,7 @@ export async function sendEmail({ to, subject, html, replyTo }: EmailOptions) {
         // In development, send all emails to the test email
         const isDevelopment = process.env.NODE_ENV === 'development';
         const testEmail = process.env.NEXT_PUBLIC_TEST_EMAIL;
-        
+
         if (isDevelopment && !testEmail) {
             throw new Error('NEXT_PUBLIC_TEST_EMAIL is required in development mode');
         }
@@ -51,9 +51,9 @@ export async function sendEmail({ to, subject, html, replyTo }: EmailOptions) {
         return { success: true, data };
     } catch (error) {
         console.error('Email sending error:', error);
-        return { 
-            success: false, 
-            error: error instanceof Error ? error.message : 'Failed to send email' 
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : 'Failed to send email'
         };
     }
 }
@@ -76,7 +76,7 @@ export function getInvitationEmailTemplate(teamName: string, inviterName: string
                 <p style="color: #4a5568; line-height: 1.6;">Hello!</p>
                 <p style="color: #4a5568; line-height: 1.6;">${inviterName} has invited you to join their team "${teamName}" on Ultimate Todo App.</p>
                 <div style="text-align: center; margin: 30px 0;">
-                    <a href="${inviteLink}" 
+                    <a href="${inviteLink}"
                        style="display: inline-block; background-color: #0070f3; color: white; padding: 12px 24px; text-decoration: none; border-radius: 4px; font-weight: 600;">
                         Accept Invitation
                     </a>
@@ -111,7 +111,7 @@ export function getTaskAssignmentEmailTemplate(taskTitle: string, assignerName: 
                 <p style="color: #4a5568; line-height: 1.6;">Hello!</p>
                 <p style="color: #4a5568; line-height: 1.6;">${assignerName} has assigned you a new task: "${taskTitle}"</p>
                 <div style="text-align: center; margin: 30px 0;">
-                    <a href="${taskLink}" 
+                    <a href="${taskLink}"
                        style="display: inline-block; background-color: #0070f3; color: white; padding: 12px 24px; text-decoration: none; border-radius: 4px; font-weight: 600;">
                         View Task
                     </a>
@@ -144,7 +144,7 @@ export function getTaskDueReminderTemplate(taskTitle: string, dueDate: string, t
                 <p style="color: #4a5568; line-height: 1.6;">Hello!</p>
                 <p style="color: #4a5568; line-height: 1.6;">This is a reminder that the task "${taskTitle}" is due on ${dueDate}.</p>
                 <div style="text-align: center; margin: 30px 0;">
-                    <a href="${taskLink}" 
+                    <a href="${taskLink}"
                        style="display: inline-block; background-color: #0070f3; color: white; padding: 12px 24px; text-decoration: none; border-radius: 4px; font-weight: 600;">
                         View Task
                     </a>
@@ -157,4 +157,41 @@ export function getTaskDueReminderTemplate(taskTitle: string, dueDate: string, t
         </body>
         </html>
     `;
-} 
+}
+
+export function buildTeamInvitationEmail(
+    data: { teamName: string; inviterName: string; inviteLink: string; recipientEmail: string },
+    replyTo: string
+): EmailOptions {
+    const { teamName, inviterName, inviteLink, recipientEmail } = data;
+    return {
+        to: recipientEmail,
+        subject: `Invitation to join ${teamName} on Ultimate Todo App`,
+        html: getInvitationEmailTemplate(teamName, inviterName, inviteLink),
+        replyTo,
+    };
+}
+
+export function buildTaskAssignmentEmail(
+    data: { taskTitle: string; assignerName: string; taskLink: string; assigneeEmail: string },
+    replyTo: string
+): EmailOptions {
+    const { taskTitle, assignerName, taskLink, assigneeEmail } = data;
+    return {
+        to: assigneeEmail,
+        subject: `New Task Assignment: ${taskTitle}`,
+        html: getTaskAssignmentEmailTemplate(taskTitle, assignerName, taskLink),
+        replyTo,
+    };
+}
+
+export function buildDueReminderEmail(
+    data: { taskTitle: string; dueDate: string; taskLink: string; userEmail: string }
+): EmailOptions {
+    const { taskTitle, dueDate, taskLink, userEmail } = data;
+    return {
+        to: userEmail,
+        subject: `Task Due Reminder: ${taskTitle}`,
+        html: getTaskDueReminderTemplate(taskTitle, dueDate, taskLink),
+    };
+}


### PR DESCRIPTION
## Summary
- move email zod schemas into dedicated app/api/email/validation module
- add lib/api/authenticateRequest for cookie-based Supabase auth
- create email builders and streamline email POST handler
- test email builders and validation schemas

## Testing
- `npx -y vitest run __tests__/email-builders.test.ts __tests__/email-validation.test.ts`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899bc767210832db4b481ac2ea23f2f