### PR TITLE
refactor: extract team service

### DIFF
--- a/__tests__/unit/teamService.test.ts
+++ b/__tests__/unit/teamService.test.ts
@@ -1,0 +1,145 @@
+import { fetchUserTeams, fetchTeamMembers, fetchPendingInvitations } from '@/lib/server/teamService'
+
+const createSupabaseMock = (responses: any) => {
+  return {
+    rpc: jest.fn().mockResolvedValue(responses.rpc),
+    from: jest.fn((table: string) => {
+      const tableResponses = responses.from[table]
+      return {
+        select: jest.fn().mockReturnThis(),
+        in: jest.fn().mockResolvedValue(tableResponses.in),
+        eq: jest.fn(function (this: any) {
+          if (!this._eqCalls) this._eqCalls = 0
+          this._eqCalls++
+          if (this._eqCalls === 2) {
+            return Promise.resolve(tableResponses.eq)
+          }
+          return this
+        }),
+      }
+    }),
+  } as any
+}
+
+describe('teamService', () => {
+  it('fetchUserTeams returns teams with roles', async () => {
+    const supabase = createSupabaseMock({
+      rpc: { data: [{ team_id: '1', team_role: 'owner' }], error: null },
+      from: {
+        teams: {
+          in: {
+            data: [
+              {
+                id: '1',
+                name: 'Team 1',
+                description: null,
+                created_at: '',
+                updated_at: '',
+              },
+            ],
+            error: null,
+          },
+        },
+      },
+    })
+
+    const teams = await fetchUserTeams(supabase, 'user1')
+    expect(teams).toEqual([
+      {
+        id: '1',
+        name: 'Team 1',
+        description: null,
+        created_at: '',
+        updated_at: '',
+        members: [],
+        role: 'owner',
+      },
+    ])
+  })
+
+  it('fetchTeamMembers groups members by team', async () => {
+    const supabase = createSupabaseMock({
+      from: {
+        team_members: {
+          in: {
+            data: [
+              {
+                id: 'm1',
+                team_id: '1',
+                role: 'member',
+                joined_at: '2024-01-01',
+                user: {
+                  id: 'u1',
+                  email: 'a@b.com',
+                  full_name: 'A',
+                  avatar_url: null,
+                },
+              },
+            ],
+            error: null,
+          },
+        },
+      },
+    })
+
+    const members = await fetchTeamMembers(supabase, ['1'])
+    expect(members).toEqual({
+      '1': [
+        {
+          id: 'm1',
+          team_id: '1',
+          user_id: 'u1',
+          role: 'member',
+          joined_at: '2024-01-01',
+          user: {
+            id: 'u1',
+            email: 'a@b.com',
+            full_name: 'A',
+            avatar_url: null,
+          },
+        },
+      ],
+    })
+  })
+
+  it('fetchPendingInvitations returns processed invitations', async () => {
+    const supabase = createSupabaseMock({
+      from: {
+        team_invitations: {
+          eq: {
+            data: [
+              {
+                id: 'i1',
+                team_id: '1',
+                email: 'a@b.com',
+                role: 'member',
+                status: 'pending',
+                invited_at: null,
+                expires_at: null,
+                token: 't',
+                team: { id: '1', name: 'Team 1', description: null },
+              },
+            ],
+            error: null,
+          },
+        },
+      },
+    })
+
+    const invitations = await fetchPendingInvitations(supabase, 'a@b.com')
+    expect(invitations).toEqual([
+      {
+        id: 'i1',
+        team_id: '1',
+        email: 'a@b.com',
+        role: 'member',
+        status: 'pending',
+        invited_at: null,
+        expires_at: null,
+        token: 't',
+        team: { id: '1', name: 'Team 1', description: null },
+      },
+    ])
+  })
+})
+

--- a/app/teams/page.tsx
+++ b/app/teams/page.tsx
@@ -3,38 +3,17 @@ import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
 import TeamsView from '@/components/teams/teams-view'
 import { Database } from '@/lib/database.types'
-import { Team, TeamMember, TeamInvitation } from '@/types/team'
+import {
+  fetchUserTeams,
+  fetchTeamMembers,
+  fetchPendingInvitations,
+} from '@/lib/server/teamService'
 
 export const dynamic = 'force-dynamic'
 
-interface TeamWithRole extends Team {
-  role: string;
-  members: TeamMember[];
-}
-
-// Define the type for user teams from RPC
-interface UserTeam {
-  team_id: string;
-  team_role: string;
-  [key: string]: any;
-}
-
-// Define the type for the member data returned from Supabase
-interface MemberData {
-  id: string;
-  team_id: string;
-  role: string;
-  user: {
-    id: string;
-    email: string;
-    full_name: string | null;
-    avatar_url: string | null;
-  };
-}
-
 export default async function TeamsPage() {
   const cookieStore = await cookies()
-  
+
   const supabase = createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
@@ -54,7 +33,10 @@ export default async function TeamsPage() {
     }
   )
 
-  const { data: { user }, error: userError } = await supabase.auth.getUser()
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
 
   if (userError || !user) {
     console.error('Auth error:', userError)
@@ -62,145 +44,22 @@ export default async function TeamsPage() {
   }
 
   try {
-    // Get user's teams using the helper function
-    const { data: userTeams, error: teamsError } = await supabase
-      .rpc('get_user_teams', {
-        p_user_id: user.id
-      })
+    const teamsWithRoles = await fetchUserTeams(supabase, user.id)
 
-    if (teamsError) {
-      console.error('Error fetching teams:', teamsError)
-      throw new Error('Failed to load teams')
-    }
+    const membersByTeam = await fetchTeamMembers(
+      supabase,
+      teamsWithRoles.map(t => t.id)
+    )
 
-    // Fetch full team details
-    const { data: teams, error: teamDetailsError } = await supabase
-      .from('teams')
-      .select('*')
-      .in('id', (userTeams || []).map((t: UserTeam) => t.team_id))
-
-    if (teamDetailsError) {
-      console.error('Error fetching team details:', teamDetailsError)
-      throw new Error('Failed to load team details')
-    }
-
-    // Combine team details with roles
-    const teamsWithRoles = (teams || []).map(team => {
-      const userTeam = userTeams?.find((ut: UserTeam) => ut.team_id === team.id)
-      return {
-        ...team,
-        role: userTeam?.team_role || 'member'
-      }
-    })
-
-    // Fetch team members for all teams
-    const { data: members, error: membersError } = await supabase
-      .from('team_members')
-      .select(`
-        id,
-        team_id,
-        role,
-        joined_at,
-        user:profiles!inner (
-          id,
-          email,
-          full_name,
-          avatar_url
-        )
-      `)
-      .in('team_id', teamsWithRoles.map(t => t.id))
-
-    if (membersError) {
-      console.error('Error fetching team members:', membersError)
-      throw new Error('Failed to load team members')
-    }
-
-    // Group members by team
-    const membersByTeam = (members || []).reduce<Record<string, TeamMember[]>>((acc, member: any) => {
-      if (!acc[member.team_id]) {
-        acc[member.team_id] = []
-      }
-      
-      // Check if user is an array and get the first item if it is
-      const userInfo = Array.isArray(member.user) ? member.user[0] : member.user;
-      
-      if (!userInfo) {
-        console.warn('Missing user info for team member:', member.id);
-        return acc; // Skip this member if no user info
-      }
-      
-      // Ensure we're creating a properly typed TeamMember object
-      const teamMember: TeamMember = {
-        id: member.id,
-        team_id: member.team_id,
-        user_id: userInfo.id,
-        role: member.role as 'owner' | 'admin' | 'member',
-        joined_at: member.joined_at || new Date().toISOString(),
-        user: {
-          id: userInfo.id,
-          email: userInfo.email,
-          full_name: userInfo.full_name,
-          avatar_url: userInfo.avatar_url
-        }
-      };
-      
-      acc[member.team_id].push(teamMember);
-      return acc;
-    }, {})
-
-    // Add members to each team
     const teamsWithMembers = teamsWithRoles.map(team => ({
       ...team,
-      members: membersByTeam[team.id] || []
+      members: membersByTeam[team.id] || [],
     }))
 
-    // Fetch pending invitations
-    const { data: invitations, error: invitationsError } = await supabase
-      .from('team_invitations')
-      .select(`
-        id,
-        team_id,
-        email,
-        role,
-        status,
-        invited_at,
-        expires_at,
-        token,
-        team:teams (
-          id,
-          name,
-          description
-        )
-      `)
-      .eq('email', user.email)
-      .eq('status', 'pending')
-
-    if (invitationsError) {
-      console.error('Error fetching invitations:', invitationsError)
-      throw new Error('Failed to load invitations')
-    }
-
-    // Process invitations to match the expected TeamInvitation type
-    const processedInvitations: TeamInvitation[] = (invitations || []).map((invitation: any) => {
-      // Check if team is an array and get the first item if it is
-      const teamInfo = Array.isArray(invitation.team) ? invitation.team[0] : invitation.team;
-      
-      return {
-        id: invitation.id,
-        team_id: invitation.team_id,
-        email: invitation.email,
-        role: invitation.role as 'owner' | 'admin' | 'member',
-        status: invitation.status as 'pending' | 'accepted' | 'rejected',
-        invited_at: invitation.invited_at,
-        expires_at: invitation.expires_at,
-        token: invitation.token,
-        team: teamInfo ? {
-          id: teamInfo.id,
-          name: teamInfo.name,
-          description: teamInfo.description
-        } : undefined
-      };
-    });
+    const processedInvitations = await fetchPendingInvitations(
+      supabase,
+      user.email!
+    )
 
     return (
       <TeamsView
@@ -214,4 +73,5 @@ export default async function TeamsPage() {
     console.error('Error loading teams page:', error)
     throw error
   }
-} 
+}
+

--- a/lib/server/teamService.ts
+++ b/lib/server/teamService.ts
@@ -1,0 +1,156 @@
+import { SupabaseClient } from '@supabase/supabase-js'
+import { Database } from '../database.types'
+import { Team, TeamMember, TeamInvitation } from '@/types/team'
+
+export interface TeamWithRole extends Team {
+  role: string
+}
+
+interface UserTeam {
+  team_id: string
+  team_role: string
+}
+
+interface MemberData {
+  id: string
+  team_id: string
+  role: string
+  joined_at?: string
+  user: {
+    id: string
+    email: string
+    full_name: string | null
+    avatar_url: string | null
+  }
+}
+
+export async function fetchUserTeams(
+  supabase: SupabaseClient<Database>,
+  userId: string
+): Promise<TeamWithRole[]> {
+  const { data: userTeams, error: teamsError } = await supabase
+    .rpc('get_user_teams', {
+      p_user_id: userId,
+    })
+
+  if (teamsError) throw teamsError
+
+  const { data: teams, error: teamDetailsError } = await supabase
+    .from('teams')
+    .select('*')
+    .in('id', (userTeams || []).map((t: UserTeam) => t.team_id))
+
+  if (teamDetailsError) throw teamDetailsError
+
+  return (teams || []).map(team => {
+    const userTeam = userTeams?.find((ut: UserTeam) => ut.team_id === team.id)
+    return {
+      ...team,
+      role: userTeam?.team_role || 'member',
+      members: [],
+    } as TeamWithRole
+  })
+}
+
+export async function fetchTeamMembers(
+  supabase: SupabaseClient<Database>,
+  teamIds: string[]
+): Promise<Record<string, TeamMember[]>> {
+  const { data: members, error } = await supabase
+    .from('team_members')
+    .select(`
+      id,
+      team_id,
+      role,
+      joined_at,
+      user:profiles!inner (
+        id,
+        email,
+        full_name,
+        avatar_url
+      )
+    `)
+    .in('team_id', teamIds)
+
+  if (error) throw error
+
+  return (members || []).reduce<Record<string, TeamMember[]>>(
+    (acc, member: MemberData) => {
+      if (!acc[member.team_id]) {
+        acc[member.team_id] = []
+      }
+
+      const userInfo = member.user
+
+      const teamMember: TeamMember = {
+        id: member.id,
+        team_id: member.team_id,
+        user_id: userInfo.id,
+        role: member.role as 'owner' | 'admin' | 'member',
+        joined_at: member.joined_at || new Date().toISOString(),
+        user: {
+          id: userInfo.id,
+          email: userInfo.email,
+          full_name: userInfo.full_name,
+          avatar_url: userInfo.avatar_url,
+        },
+      }
+
+      acc[member.team_id].push(teamMember)
+      return acc
+    },
+    {}
+  )
+}
+
+export async function fetchPendingInvitations(
+  supabase: SupabaseClient<Database>,
+  email: string
+): Promise<TeamInvitation[]> {
+  const { data: invitations, error } = await supabase
+    .from('team_invitations')
+    .select(`
+      id,
+      team_id,
+      email,
+      role,
+      status,
+      invited_at,
+      expires_at,
+      token,
+      team:teams (
+        id,
+        name,
+        description
+      )
+    `)
+    .eq('email', email)
+    .eq('status', 'pending')
+
+  if (error) throw error
+
+  return (invitations || []).map((invitation: any) => {
+    const teamInfo = Array.isArray(invitation.team)
+      ? invitation.team[0]
+      : invitation.team
+
+    return {
+      id: invitation.id,
+      team_id: invitation.team_id,
+      email: invitation.email,
+      role: invitation.role as 'owner' | 'admin' | 'member',
+      status: invitation.status as 'pending' | 'accepted' | 'rejected',
+      invited_at: invitation.invited_at,
+      expires_at: invitation.expires_at,
+      token: invitation.token,
+      team: teamInfo
+        ? {
+            id: teamInfo.id,
+            name: teamInfo.name,
+            description: teamInfo.description,
+          }
+        : undefined,
+    } as TeamInvitation
+  })
+}
+


### PR DESCRIPTION
## Summary
- add server-side team service functions for teams, members, and invitations
- refactor teams page to use centralized team service
- add unit tests for team service using mocked Supabase client

## Testing
- `pnpm lint`
- `pnpm dlx jest __tests__/unit/teamService.test.ts __tests__/integration/team-collaboration.test.tsx` *(fails: SyntaxError, missing Babel configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6899bc74b640832d9d7365489c89f95b