### PR TITLE
feat: add AI project planner

### DIFF
--- a/__tests__/api/project-planner.test.ts
+++ b/__tests__/api/project-planner.test.ts
@@ -1,0 +1,41 @@
+import { POST } from '@/app/api/ai/project-planner/route'
+
+jest.mock('openai', () => {
+  return {
+    OpenAI: function () {
+      return {
+        chat: {
+          completions: {
+            create: jest.fn().mockResolvedValue({
+              choices: [
+                {
+                  message: {
+                    content: JSON.stringify({
+                      tasks: [
+                        { title: 'Plan party', tasks: [{ title: 'Send invites' }] }
+                      ]
+                    })
+                  }
+                }
+              ]
+            })
+          }
+        }
+      }
+    }
+  }
+})
+
+describe('project planner API', () => {
+  it('returns nested tasks for a goal', async () => {
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({ goal: 'Birthday party' })
+    })
+
+    const res = await POST(req)
+    const json = await res.json()
+
+    expect(json.tasks[0].tasks[0].title).toBe('Send invites')
+  })
+})

--- a/app/api/ai/project-planner/route.ts
+++ b/app/api/ai/project-planner/route.ts
@@ -1,0 +1,45 @@
+import { OpenAI } from 'openai'
+import { NextResponse } from 'next/server'
+
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY
+})
+
+export async function POST(request: Request) {
+  try {
+    const { goal } = await request.json()
+
+    const prompt = `You are an expert project planner. Break the following goal into a structured plan with tasks and subtasks.
+
+Goal: "${goal}"
+
+Return a JSON object with a 'tasks' array. Each task should have a 'title' and an optional 'tasks' array for subtasks.
+Example: {"tasks":[{"title":"Task A","tasks":[{"title":"Subtask"}]}]}`
+
+    const completion = await openai.chat.completions.create({
+      model: 'gpt-4-turbo-preview',
+      messages: [
+        {
+          role: 'system',
+          content: 'You create detailed project plans as nested tasks. Always respond with valid JSON.'
+        },
+        {
+          role: 'user',
+          content: prompt
+        }
+      ],
+      temperature: 0.7,
+      max_tokens: 800,
+      response_format: { type: 'json_object' }
+    })
+
+    const plan = JSON.parse(completion.choices[0].message.content || '{"tasks": []}')
+    return NextResponse.json(plan)
+  } catch (error) {
+    console.error('Error planning project:', error)
+    return NextResponse.json(
+      { error: 'Failed to plan project' },
+      { status: 500 }
+    )
+  }
+}

--- a/components/ai/ai-assistant.tsx
+++ b/components/ai/ai-assistant.tsx
@@ -55,6 +55,54 @@ export function AIAssistant() {
     }, 1000)
   }
 
+  const formatTasks = (tasks: any[], indent = 0): string => {
+    return tasks
+      .map(
+        (task: any) =>
+          `${'  '.repeat(indent)}- ${task.title}` +
+          (task.tasks ? `\n${formatTasks(task.tasks, indent + 1)}` : '')
+      )
+      .join('\n')
+  }
+
+  const handlePlanGoal = async () => {
+    if (!input.trim()) return
+
+    const userMessage: Message = {
+      id: Date.now().toString(),
+      role: 'user',
+      content: input,
+      timestamp: new Date()
+    }
+
+    setMessages((prev) => [...prev, userMessage])
+    setInput('')
+    setIsLoading(true)
+
+    try {
+      const res = await fetch('/api/ai/project-planner', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ goal: userMessage.content })
+      })
+      const data = await res.json()
+      const content = formatTasks(data.tasks || [])
+
+      const aiMessage: Message = {
+        id: (Date.now() + 1).toString(),
+        role: 'assistant',
+        content,
+        timestamp: new Date()
+      }
+
+      setMessages((prev) => [...prev, aiMessage])
+    } catch (e) {
+      console.error(e)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
   // Simple mock AI response function
   const getAIResponse = (userInput: string) => {
     const input = userInput.toLowerCase()
@@ -149,6 +197,12 @@ export function AIAssistant() {
                 disabled={!input.trim() || isLoading}
               >
                 <Send className="h-4 w-4" />
+              </Button>
+              <Button
+                onClick={handlePlanGoal}
+                disabled={!input.trim() || isLoading}
+              >
+                Plan this goal
               </Button>
               <Button
                 size="icon"

--- a/supabase/migrations/20240324000027_add_planned_projects.sql
+++ b/supabase/migrations/20240324000027_add_planned_projects.sql
@@ -1,0 +1,60 @@
+-- Create table for planned projects
+CREATE TABLE planned_projects (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID REFERENCES auth.users NOT NULL,
+    goal TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
+);
+
+-- Enable RLS
+ALTER TABLE planned_projects ENABLE ROW LEVEL SECURITY;
+
+-- Policies
+CREATE POLICY "Users can manage their planned projects" ON planned_projects
+    USING (user_id = auth.uid())
+    WITH CHECK (user_id = auth.uid());
+
+-- Table for tasks within planned projects
+CREATE TABLE planned_tasks (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_id UUID REFERENCES planned_projects(id) ON DELETE CASCADE,
+    parent_id UUID REFERENCES planned_tasks(id) ON DELETE CASCADE,
+    title TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
+);
+
+-- Enable RLS
+ALTER TABLE planned_tasks ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can manage their planned tasks" ON planned_tasks
+    USING (
+        EXISTS (
+            SELECT 1 FROM planned_projects p
+            WHERE p.id = planned_tasks.project_id
+            AND p.user_id = auth.uid()
+        )
+    )
+    WITH CHECK (
+        EXISTS (
+            SELECT 1 FROM planned_projects p
+            WHERE p.id = planned_tasks.project_id
+            AND p.user_id = auth.uid()
+        )
+    );
+
+-- Indexes for faster lookups
+CREATE INDEX idx_planned_tasks_project_id ON planned_tasks(project_id);
+CREATE INDEX idx_planned_tasks_parent_id ON planned_tasks(parent_id);
+
+-- Triggers for updated_at
+CREATE TRIGGER set_planned_projects_updated_at
+    BEFORE UPDATE ON planned_projects
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER set_planned_tasks_updated_at
+    BEFORE UPDATE ON planned_tasks
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();


### PR DESCRIPTION
## Summary
- add OpenAI-powered project planner API
- expose "Plan this goal" action in AI assistant
- support storing planned projects and tasks in database
- cover project planner endpoint with integration test

## Testing
- `pnpm lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a3f233f0c832d95906358c428e30b