### PR TITLE
feat: add vision and voice task input

### DIFF
--- a/__tests__/api/vision.test.ts
+++ b/__tests__/api/vision.test.ts
@@ -1,0 +1,35 @@
+import { POST } from '@/app/api/vision/route'
+
+jest.mock('openai', () => ({
+  __esModule: true,
+  default: function () {
+    return {
+      chat: {
+        completions: {
+          create: jest.fn().mockResolvedValue({
+            choices: [
+              { message: { content: 'Buy milk' } }
+            ]
+          })
+        }
+      }
+    }
+  }
+}))
+
+describe('vision API', () => {
+  it('extracts text from image', async () => {
+    const blob = new Blob(['fake'], { type: 'image/png' })
+    const formData = new FormData()
+    formData.append('image', blob)
+
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: formData,
+    })
+
+    const res = await POST(req)
+    const json = await res.json()
+    expect(json.text).toBe('Buy milk')
+  })
+})

--- a/app/api/vision/route.ts
+++ b/app/api/vision/route.ts
@@ -27,7 +27,12 @@ export async function POST(request: Request) {
           role: 'user',
           content: [
             { type: 'text', text: 'Extract the text from this image.' },
-            { type: 'image_url', image_url: `data:${image.type};base64,${base64}` }
+            {
+              type: 'image_url',
+              image_url: {
+                url: `data:${image.type};base64,${base64}`,
+              },
+            },
           ],
         },
       ],

--- a/app/api/vision/route.ts
+++ b/app/api/vision/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from 'next/server'
+import OpenAI from 'openai'
+
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+})
+
+export async function POST(request: Request) {
+  try {
+    const formData = await request.formData()
+    const image = formData.get('image') as Blob
+
+    if (!image) {
+      return NextResponse.json(
+        { error: 'No image file provided' },
+        { status: 400 }
+      )
+    }
+
+    const buffer = Buffer.from(await image.arrayBuffer())
+    const base64 = buffer.toString('base64')
+
+    const result = await openai.chat.completions.create({
+      model: 'gpt-4o-mini',
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Extract the text from this image.' },
+            { type: 'image_url', image_url: `data:${image.type};base64,${base64}` }
+          ],
+        },
+      ],
+    })
+
+    const text = result.choices[0].message?.content || ''
+    return NextResponse.json({ text })
+  } catch (error) {
+    console.error('Error in Vision API:', error)
+    return NextResponse.json(
+      {
+        error: 'Failed to process image',
+        details: error instanceof Error ? error.message : String(error),
+      },
+      { status: 500 }
+    )
+  }
+}
+
+export async function GET() {
+  if (!process.env.OPENAI_API_KEY) {
+    return NextResponse.json(
+      { error: 'OpenAI API key not configured' },
+      { status: 500 }
+    )
+  }
+  return NextResponse.json({ status: 'OpenAI Vision API is configured' })
+}

--- a/app/api/whisper/route.ts
+++ b/app/api/whisper/route.ts
@@ -1,9 +1,5 @@
 import { NextResponse } from 'next/server'
-import OpenAI from 'openai'
-
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-})
+import { transcribeAudio } from '@/lib/ai/transcription'
 
 export async function POST(request: Request) {
   try {
@@ -17,17 +13,9 @@ export async function POST(request: Request) {
       )
     }
 
-    // Convert Blob to File object
-    const file = new File([audioFile], 'audio.webm', { type: audioFile.type })
+    const text = await transcribeAudio(audioFile)
 
-    // Transcribe using OpenAI Whisper API
-    const transcription = await openai.audio.transcriptions.create({
-      file: file,
-      model: 'whisper-1',
-      language: 'en',
-    })
-
-    return NextResponse.json({ text: transcription.text })
+    return NextResponse.json({ text })
   } catch (error) {
     console.error('Error in Whisper API:', error)
     return NextResponse.json(

--- a/components/quick-add-task-bar.tsx
+++ b/components/quick-add-task-bar.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import { useState, useEffect } from 'react'
-import { Plus, Wand2 } from 'lucide-react'
+import { useState, useEffect, useRef } from 'react'
+import { Plus, Wand2, Mic, Camera } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import type { Task, TaskTemplate } from '@/lib/types'
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui/popover"
 import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
+import { SpeechRecognitionService } from '@/lib/speech-recognition'
 
 interface QuickAddTaskBarProps {
   columnId: string
@@ -41,10 +42,18 @@ export function QuickAddTaskBar({
   const [selectedProject, setSelectedProject] = useState<string>('none')
   const [suggestions, setSuggestions] = useState<Partial<Task>[]>([])
   const [isLoadingSuggestions, setIsLoadingSuggestions] = useState(false)
-
+  const [isListening, setIsListening] = useState(false)
+  const [speechService] = useState(() => new SpeechRecognitionService())
+  const [isProcessingImage, setIsProcessingImage] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
   useEffect(() => {
     setMounted(true)
-  }, [])
+    return () => {
+      if (speechService.isCurrentlyRecording()) {
+        speechService.stopRecording().catch(console.error)
+      }
+    }
+  }, [speechService])
 
   const handleAddTask = async () => {
     if (!taskTitle.trim() || !onAddTask) return
@@ -114,6 +123,51 @@ export function QuickAddTaskBar({
     }
   }
 
+  const toggleRecording = async () => {
+    try {
+      if (!isListening) {
+        await speechService.startRecording()
+        setIsListening(true)
+        toast.info('Recording...')
+      } else {
+        const text = await speechService.stopRecording()
+        setTaskTitle(text)
+        setIsListening(false)
+        toast.success('Transcribed voice input')
+      }
+    } catch (error) {
+      console.error('Speech recognition error:', error)
+      toast.error('Failed to process audio')
+      setIsListening(false)
+    }
+  }
+
+  const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    try {
+      setIsProcessingImage(true)
+      const formData = new FormData()
+      formData.append('image', file)
+      const res = await fetch('/api/vision', {
+        method: 'POST',
+        body: formData,
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        throw new Error(data.error || 'Failed to extract text')
+      }
+      setTaskTitle(data.text)
+      toast.success('Extracted text from image')
+    } catch (error) {
+      console.error('Image processing error:', error)
+      toast.error('Failed to extract text')
+    } finally {
+      setIsProcessingImage(false)
+      if (fileInputRef.current) fileInputRef.current.value = ''
+    }
+  }
+
   const handleKeyPress = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()
@@ -159,6 +213,30 @@ export function QuickAddTaskBar({
           onKeyDown={handleKeyPress}
           placeholder="Enter task title..."
           autoFocus
+        />
+        <Button
+          variant="outline"
+          size="icon"
+          className={cn(isListening && 'animate-pulse')}
+          onClick={() => void toggleRecording()}
+          disabled={isProcessingImage}
+        >
+          <Mic className="h-4 w-4" />
+        </Button>
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={isListening || isProcessingImage}
+        >
+          <Camera className="h-4 w-4" />
+        </Button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          onChange={handleImageChange}
+          className="hidden"
         />
         {getAISuggestions && (
           <Popover>

--- a/docs/INPUT_MODES.md
+++ b/docs/INPUT_MODES.md
@@ -1,0 +1,9 @@
+# Task Input Modes
+
+The application supports multiple ways to add tasks:
+
+- **Typing** – enter a title manually in any task field.
+- **Voice** – tap the microphone in quick-add bars to record audio. The `/api/whisper` endpoint transcribes the recording into task text.
+- **Image** – use the camera button to upload a picture containing text. The `/api/vision` endpoint performs OCR and returns the detected text.
+
+Both voice and image uploads return plain text that is inserted into the task title before creation.

--- a/lib/ai/transcription.ts
+++ b/lib/ai/transcription.ts
@@ -1,0 +1,15 @@
+import OpenAI from 'openai'
+
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+})
+
+export async function transcribeAudio(audio: Blob): Promise<string> {
+  const file = new File([audio], 'audio.webm', { type: audio.type })
+  const transcription = await openai.audio.transcriptions.create({
+    file,
+    model: 'whisper-1',
+    language: 'en',
+  })
+  return transcription.text
+}


### PR DESCRIPTION
## Summary
- add shared transcription helper and update whisper endpoint
- support image OCR via new vision API
- microphone and camera task capture buttons, plus docs and test

## Testing
- `npm run lint`
- `npx --yes jest __tests__/api/vision.test.ts --runInBand` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_689a42b776e0832d8916dfc200a727a2