### PR TITLE
feat: add daily summary digest

### DIFF
--- a/__tests__/api/daily-summary.test.ts
+++ b/__tests__/api/daily-summary.test.ts
@@ -1,0 +1,43 @@
+import { POST } from '@/app/api/ai/daily-summary/route'
+
+jest.mock('openai', () => {
+  return {
+    OpenAI: function () {
+      return {
+        chat: {
+          completions: {
+            create: jest.fn().mockResolvedValue({
+              choices: [
+                { message: { content: 'You have 1 task today' } }
+              ]
+            })
+          }
+        }
+      }
+    }
+  }
+})
+
+jest.mock('@/lib/supabase-server', () => ({
+  createClient: async () => ({
+    auth: {
+      getUser: async () => ({ data: { user: { id: '123', email: 'test@example.com' } } })
+    }
+  })
+}))
+
+jest.mock('@/lib/email', () => ({
+  sendEmail: jest.fn().mockResolvedValue({ success: true })
+}))
+
+describe('daily summary API', () => {
+  it('returns a summary for provided tasks', async () => {
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({ tasks: [{ title: 'Test Task', status: 'To Do', due_date: new Date().toISOString() }] })
+    })
+    const res = await POST(req as any)
+    const json = await res.json()
+    expect(json.summary).toBe('You have 1 task today')
+  })
+})

--- a/app/api/ai/daily-summary/route.ts
+++ b/app/api/ai/daily-summary/route.ts
@@ -47,16 +47,16 @@ export async function POST(req: Request) {
       userEmail = user.email || undefined
     }
 
-    // Allow tests to pass custom tasks
+    // Allow tests to pass custom tasks; otherwise fetch today's tasks
     let body: any = {}
     try {
       body = await req.json()
     } catch (e) {
       // ignore
     }
-    let tasks: Task[] | undefined = body.tasks
+    let tasks: Task[] = body.tasks ?? []
 
-    if (!tasks) {
+    if (body.tasks === undefined) {
       const start = new Date()
       start.setUTCHours(0, 0, 0, 0)
       const end = new Date()

--- a/app/api/ai/daily-summary/route.ts
+++ b/app/api/ai/daily-summary/route.ts
@@ -1,0 +1,108 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase-server'
+import { OpenAI } from 'openai'
+import { sendEmail } from '@/lib/email'
+import { createClient as createServiceClient } from '@supabase/supabase-js'
+
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY
+})
+
+interface Task {
+  title: string
+  status: string
+  due_date: string
+}
+
+export async function POST(req: Request) {
+  try {
+    const authHeader = req.headers.get('authorization')
+    const isCron = authHeader === `Bearer ${process.env.CRON_SECRET}`
+    let supabase: any
+    let userId: string
+    let userEmail: string | undefined
+
+    if (isCron) {
+      const { userId: bodyUserId } = await req.json()
+      if (!bodyUserId) {
+        return NextResponse.json({ error: 'userId required' }, { status: 400 })
+      }
+      if (!process.env.SUPABASE_SERVICE_ROLE_KEY || !process.env.NEXT_PUBLIC_SUPABASE_URL) {
+        return NextResponse.json({ error: 'Service role key not configured' }, { status: 500 })
+      }
+      supabase = createServiceClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY)
+      const { data: userData } = await supabase.auth.admin.getUserById(bodyUserId)
+      if (!userData.user) {
+        return NextResponse.json({ error: 'User not found' }, { status: 404 })
+      }
+      userId = bodyUserId
+      userEmail = userData.user.email || undefined
+    } else {
+      supabase = await createClient()
+      const { data: { user }, error: userError } = await supabase.auth.getUser()
+      if (userError || !user) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+      }
+      userId = user.id
+      userEmail = user.email || undefined
+    }
+
+    // Allow tests to pass custom tasks
+    let body: any = {}
+    try {
+      body = await req.json()
+    } catch (e) {
+      // ignore
+    }
+    let tasks: Task[] | undefined = body.tasks
+
+    if (!tasks) {
+      const start = new Date()
+      start.setUTCHours(0, 0, 0, 0)
+      const end = new Date()
+      end.setUTCHours(23, 59, 59, 999)
+
+      const { data: fetchedTasks, error: taskError } = await supabase
+        .from('tasks')
+        .select('title,status,due_date')
+        .eq('user_id', userId)
+        .gte('due_date', start.toISOString())
+        .lt('due_date', end.toISOString())
+
+      if (taskError) {
+        console.error('Error fetching tasks:', taskError)
+        return NextResponse.json({ error: 'Failed to fetch tasks' }, { status: 500 })
+      }
+      tasks = fetchedTasks || []
+    }
+
+    const taskText = tasks.length
+      ? tasks.map(t => `- ${t.title} (${t.status})`).join('\n')
+      : 'No tasks for today.'
+
+    const prompt = `Provide a concise daily summary for these tasks:\n${taskText}\nKeep it short and encouraging.`
+
+    const completion = await openai.chat.completions.create({
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: prompt }],
+      max_tokens: 150,
+      temperature: 0.7
+    })
+
+    const summary = completion.choices[0].message?.content?.trim() || 'No summary available.'
+
+    if (userEmail) {
+      await sendEmail({
+        to: userEmail,
+        subject: 'Your Daily Task Summary',
+        html: `<p>${summary}</p>`
+      })
+    }
+
+    return NextResponse.json({ summary })
+  } catch (error) {
+    console.error('Error generating daily summary:', error)
+    return NextResponse.json({ error: 'Failed to generate summary' }, { status: 500 })
+  }
+}
+

--- a/components/settings/ai-planning-settings.tsx
+++ b/components/settings/ai-planning-settings.tsx
@@ -43,6 +43,7 @@ const aiPlanningFormSchema = z.object({
   timeEstimation: z.boolean().default(true),
   dailyPlanning: z.boolean().default(true),
   weeklyReview: z.boolean().default(true),
+  dailyDigest: z.boolean().default(false),
   aiAggressiveness: z.number().min(1).max(10).default(5),
   customInstructions: z.string().optional(),
   dataSharing: z.boolean().default(false),
@@ -63,6 +64,7 @@ export function AIPlanningSettings({ user }: { user: User }) {
     timeEstimation: user.user_metadata?.time_estimation !== false, // Default to true
     dailyPlanning: user.user_metadata?.daily_planning !== false, // Default to true
     weeklyReview: user.user_metadata?.weekly_review !== false, // Default to true
+    dailyDigest: user.user_metadata?.daily_digest === true,
     aiAggressiveness: user.user_metadata?.ai_aggressiveness || 5,
     customInstructions: user.user_metadata?.custom_instructions || "",
     dataSharing: user.user_metadata?.data_sharing || false,
@@ -84,14 +86,15 @@ export function AIPlanningSettings({ user }: { user: User }) {
           custom_endpoint: data.customEndpoint,
           task_suggestions: data.taskSuggestions,
           task_prioritization: data.taskPrioritization,
-          time_estimation: data.timeEstimation,
-          daily_planning: data.dailyPlanning,
-          weekly_review: data.weeklyReview,
-          ai_aggressiveness: data.aiAggressiveness,
-          custom_instructions: data.customInstructions,
-          data_sharing: data.dataSharing,
-        },
-      });
+        time_estimation: data.timeEstimation,
+        daily_planning: data.dailyPlanning,
+        weekly_review: data.weeklyReview,
+        daily_digest: data.dailyDigest,
+        ai_aggressiveness: data.aiAggressiveness,
+        custom_instructions: data.customInstructions,
+        data_sharing: data.dataSharing,
+      },
+    });
 
       if (error) {
         throw error;
@@ -367,8 +370,29 @@ export function AIPlanningSettings({ user }: { user: User }) {
                       </FormItem>
                     )}
                   />
+
+                  <FormField
+                    control={form.control}
+                    name="dailyDigest"
+                    render={({ field }) => (
+                      <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+                        <div className="space-y-0.5">
+                          <FormLabel className="text-base">Daily Digest</FormLabel>
+                          <FormDescription>
+                            Receive a daily email summary of your tasks.
+                          </FormDescription>
+                        </div>
+                        <FormControl>
+                          <Switch
+                            checked={field.value}
+                            onCheckedChange={field.onChange}
+                          />
+                        </FormControl>
+                      </FormItem>
+                    )}
+                  />
                 </div>
-                
+
                 <Separator />
                 
                 <FormField

--- a/supabase/functions/daily-summary/index.ts
+++ b/supabase/functions/daily-summary/index.ts
@@ -1,0 +1,28 @@
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+serve(async () => {
+  const url = Deno.env.get('NEXT_PUBLIC_APP_URL')!
+  const cronSecret = Deno.env.get('CRON_SECRET')!
+  const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+  const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+  const supabase = createClient(supabaseUrl, serviceKey)
+
+  const { data: { users } } = await supabase.auth.admin.listUsers()
+  for (const user of users) {
+    if (user.user_metadata?.daily_digest) {
+      await fetch(`${url}/api/ai/daily-summary`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${cronSecret}`
+        },
+        body: JSON.stringify({ userId: user.id })
+      })
+    }
+  }
+
+  return new Response(JSON.stringify({ success: true }), {
+    headers: { 'Content-Type': 'application/json' }
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,7 @@
     ".next/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "supabase"
   ]
 }


### PR DESCRIPTION
## Summary
- add daily summary API that emails a concise task digest
- schedule daily digests via Supabase Edge Function
- add Daily Digest toggle in AI planning settings

## Testing
- `pnpm lint`
- `npx jest __tests__/api/daily-summary.test.ts` *(fails: npm error canceled)*

------
https://chatgpt.com/codex/tasks/task_e_689ba00e0ee0832dabd60d2ea4347068