### PR TITLE
feat: add daily summary digest

### DIFF
--- a/__tests__/api/daily-summary.test.ts
+++ b/__tests__/api/daily-summary.test.ts
@@ -1,0 +1,43 @@
+import { POST } from '@/app/api/ai/daily-summary/route'
+import { sendEmail } from '@/lib/email'
+
+jest.mock('openai', () => {
+  return {
+    OpenAI: function () {
+      return {
+        chat: {
+          completions: {
+            create: jest.fn().mockResolvedValue({
+              choices: [{ message: { content: 'Mock summary' } }]
+            })
+          }
+        }
+      }
+    }
+  }
+})
+
+jest.mock('@/lib/email', () => ({
+  sendEmail: jest.fn().mockResolvedValue({ success: true })
+}))
+
+describe('daily summary API', () => {
+  it('returns a summary for provided tasks', async () => {
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({
+        tasks: [
+          { title: 'Task 1', status: 'done' },
+          { title: 'Task 2', status: 'open' }
+        ],
+        email: 'user@example.com'
+      })
+    })
+
+    const res = await POST(req)
+    const json = await res.json()
+
+    expect(json.summary).toBe('Mock summary')
+    expect(sendEmail).toHaveBeenCalled()
+  })
+})

--- a/app/api/ai/daily-summary/route.ts
+++ b/app/api/ai/daily-summary/route.ts
@@ -1,0 +1,79 @@
+import { NextResponse } from 'next/server'
+import { OpenAI } from 'openai'
+import { createClient } from '@/lib/supabase-server'
+import { sendEmail } from '@/lib/email'
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json().catch(() => ({}))
+    let tasks: { title: string; status: string }[] | undefined = body.tasks
+    let email: string | undefined = body.email
+
+    if (!tasks) {
+      const supabase = await createClient()
+      const {
+        data: { user }
+      } = await supabase.auth.getUser()
+
+      if (!user) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+      }
+
+      email = user.email
+      const today = new Date().toISOString().split('T')[0]
+      const { data, error } = await supabase
+        .from('tasks')
+        .select('title, status')
+        .eq('user_id', user.id)
+        .eq('due_date', today)
+
+      if (error) throw error
+      tasks = data || []
+    }
+
+    const taskLines = (tasks || [])
+      .map((t) => `- ${t.title} (${t.status})`)
+      .join('\n')
+
+    const prompt = `Summarize the following tasks for a brief daily digest:\n${taskLines}\nSummary:`
+
+    const completion = await openai.chat.completions.create({
+      model: 'gpt-4-turbo-preview',
+      messages: [
+        {
+          role: 'system',
+          content: 'You are a helpful assistant that summarizes task lists.'
+        },
+        { role: 'user', content: prompt }
+      ],
+      temperature: 0.5,
+      max_tokens: 150
+    })
+
+    const summary = completion.choices[0].message.content?.trim() || ''
+
+    if (email && summary) {
+      const html = `<p>${summary}</p>`
+      try {
+        await sendEmail({
+          to: email,
+          subject: 'Daily Task Summary',
+          html
+        })
+      } catch (err) {
+        console.error('Failed to send summary email:', err)
+      }
+    }
+
+    return NextResponse.json({ summary })
+  } catch (error) {
+    console.error('Error generating daily summary:', error)
+    return NextResponse.json(
+      { error: 'Failed to generate summary' },
+      { status: 500 }
+    )
+  }
+}
+

--- a/components/settings/ai-planning-settings.tsx
+++ b/components/settings/ai-planning-settings.tsx
@@ -43,6 +43,7 @@ const aiPlanningFormSchema = z.object({
   timeEstimation: z.boolean().default(true),
   dailyPlanning: z.boolean().default(true),
   weeklyReview: z.boolean().default(true),
+  dailyDigest: z.boolean().default(false),
   aiAggressiveness: z.number().min(1).max(10).default(5),
   customInstructions: z.string().optional(),
   dataSharing: z.boolean().default(false),
@@ -62,11 +63,12 @@ export function AIPlanningSettings({ user }: { user: User }) {
     taskPrioritization: user.user_metadata?.task_prioritization !== false, // Default to true
     timeEstimation: user.user_metadata?.time_estimation !== false, // Default to true
     dailyPlanning: user.user_metadata?.daily_planning !== false, // Default to true
-    weeklyReview: user.user_metadata?.weekly_review !== false, // Default to true
-    aiAggressiveness: user.user_metadata?.ai_aggressiveness || 5,
-    customInstructions: user.user_metadata?.custom_instructions || "",
-    dataSharing: user.user_metadata?.data_sharing || false,
-  };
+  weeklyReview: user.user_metadata?.weekly_review !== false, // Default to true
+  dailyDigest: user.user_metadata?.daily_digest || false,
+  aiAggressiveness: user.user_metadata?.ai_aggressiveness || 5,
+  customInstructions: user.user_metadata?.custom_instructions || "",
+  dataSharing: user.user_metadata?.data_sharing || false,
+};
 
   const form = useForm<AIPlanningFormValues>({
     resolver: zodResolver(aiPlanningFormSchema),
@@ -87,6 +89,7 @@ export function AIPlanningSettings({ user }: { user: User }) {
           time_estimation: data.timeEstimation,
           daily_planning: data.dailyPlanning,
           weekly_review: data.weeklyReview,
+          daily_digest: data.dailyDigest,
           ai_aggressiveness: data.aiAggressiveness,
           custom_instructions: data.customInstructions,
           data_sharing: data.dataSharing,
@@ -347,9 +350,9 @@ export function AIPlanningSettings({ user }: { user: User }) {
                     )}
                   />
                   
-                  <FormField
-                    control={form.control}
-                    name="weeklyReview"
+                    <FormField
+                      control={form.control}
+                      name="weeklyReview"
                     render={({ field }) => (
                       <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
                         <div className="space-y-0.5">
@@ -366,8 +369,29 @@ export function AIPlanningSettings({ user }: { user: User }) {
                         </FormControl>
                       </FormItem>
                     )}
-                  />
-                </div>
+                    />
+
+                    <FormField
+                      control={form.control}
+                      name="dailyDigest"
+                      render={({ field }) => (
+                        <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+                          <div className="space-y-0.5">
+                            <FormLabel className="text-base">Daily Summary Email</FormLabel>
+                            <FormDescription>
+                              Receive a daily email with a summary of your tasks.
+                            </FormDescription>
+                          </div>
+                          <FormControl>
+                            <Switch
+                              checked={field.value}
+                              onCheckedChange={field.onChange}
+                            />
+                          </FormControl>
+                        </FormItem>
+                      )}
+                    />
+                  </div>
                 
                 <Separator />
                 

--- a/supabase/functions/daily-summary/index.ts
+++ b/supabase/functions/daily-summary/index.ts
@@ -1,0 +1,13 @@
+import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
+
+// This Edge Function triggers the daily summary API route.
+// It can be scheduled using Supabase's cron feature.
+serve(async () => {
+  const url = Deno.env.get('NEXT_PUBLIC_APP_URL') ?? ''
+  if (url) {
+    await fetch(`${url}/api/ai/daily-summary`, { method: 'POST' })
+  }
+  return new Response(JSON.stringify({ success: true }), {
+    headers: { 'Content-Type': 'application/json' }
+  })
+})


### PR DESCRIPTION
## Summary
- add daily summary API that gathers tasks, summarizes them with OpenAI, and emails the result
- provide Supabase Edge Function to trigger the summary on a schedule
- add user setting for opting into daily digest and test covering API summary

## Testing
- `npx -y jest __tests__/api/daily-summary.test.ts` *(fails: Jest encountered an unexpected token)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689ba5b3690c832db3846dc41487af39