### PR TITLE
feat: add habit metrics and streak tracking

### DIFF
--- a/__tests__/components/dashboard.test.tsx
+++ b/__tests__/components/dashboard.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react'
+import Dashboard from '@/components/dashboard'
+
+const noopFn = () => {}
+const chartData: { name: string; value: number }[] = []
+
+describe('Dashboard metrics', () => {
+  it('renders productivity score and streak', () => {
+    render(
+      <Dashboard
+        chartData={chartData}
+        aiSuggestion=""
+        getAISuggestions={noopFn}
+        applyAISuggestion={noopFn}
+        productivityScore={20}
+        streak={3}
+      />
+    )
+    expect(screen.getByTestId('productivity-score').textContent).toBe('20')
+    expect(screen.getByText('3 day streak')).toBeInTheDocument()
+  })
+
+  it('updates score and shows milestone badge', () => {
+    const { rerender } = render(
+      <Dashboard
+        chartData={chartData}
+        aiSuggestion=""
+        getAISuggestions={noopFn}
+        applyAISuggestion={noopFn}
+        productivityScore={10}
+        streak={4}
+      />
+    )
+    rerender(
+      <Dashboard
+        chartData={chartData}
+        aiSuggestion=""
+        getAISuggestions={noopFn}
+        applyAISuggestion={noopFn}
+        productivityScore={50}
+        streak={5}
+      />
+    )
+    expect(screen.getByTestId('productivity-score').textContent).toBe('50')
+    expect(screen.getByText('5 day streak 🎉')).toBeInTheDocument()
+  })
+})

--- a/components/dashboard.tsx
+++ b/components/dashboard.tsx
@@ -2,15 +2,18 @@ import {Card, CardContent, CardHeader, CardTitle} from '@/components/ui/card';
 import {Cell, Pie, PieChart, ResponsiveContainer, Tooltip} from 'recharts';
 import {Button} from '@/components/ui/button';
 import {BrainIcon, MoreVerticalIcon} from 'lucide-react';
+import { StreakBadge } from '@/components/ui/streak-badge';
 
 interface DashboardProps {
     chartData: { name: string; value: number }[];
     aiSuggestion: string;
     getAISuggestions: () => void;
     applyAISuggestion: () => void;
+    productivityScore: number;
+    streak: number;
 }
 
-export default function Dashboard({chartData, aiSuggestion, getAISuggestions, applyAISuggestion}: DashboardProps) {
+export default function Dashboard({chartData, aiSuggestion, getAISuggestions, applyAISuggestion, productivityScore, streak}: DashboardProps) {
     return (
         <div>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
@@ -63,6 +66,15 @@ export default function Dashboard({chartData, aiSuggestion, getAISuggestions, ap
                     </CardContent>
                 </Card>
             </div>
+            <Card className="mb-6">
+                <CardHeader>
+                    <CardTitle>Productivity Score</CardTitle>
+                </CardHeader>
+                <CardContent className="flex items-center space-x-2">
+                    <div className="text-2xl font-bold" data-testid="productivity-score">{productivityScore}</div>
+                    <StreakBadge streak={streak} />
+                </CardContent>
+            </Card>
             <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
                 <Card>
                     <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">

--- a/components/ui/streak-badge.tsx
+++ b/components/ui/streak-badge.tsx
@@ -1,0 +1,24 @@
+import { motion } from 'framer-motion'
+import { Badge } from './badge'
+
+interface StreakBadgeProps {
+  streak: number
+}
+
+export function StreakBadge({ streak }: StreakBadgeProps) {
+  const milestone = streak > 0 && streak % 5 === 0
+  return (
+    <motion.div
+      initial={{ scale: 0 }}
+      animate={{ scale: 1 }}
+      className="inline-block"
+      data-testid="streak-badge-wrapper"
+    >
+      <Badge variant={milestone ? 'success' : 'secondary'} data-testid="streak-badge">
+        {streak} day streak{milestone ? ' 🎉' : ''}
+      </Badge>
+    </motion.div>
+  )
+}
+
+export default StreakBadge

--- a/database.types.ts
+++ b/database.types.ts
@@ -139,6 +139,35 @@ export type Database = {
         }
         Relationships: []
       }
+      habit_metrics: {
+        Row: {
+          user_id: string
+          streak: number
+          points: number
+          updated_at: string | null
+        }
+        Insert: {
+          user_id: string
+          streak?: number
+          points?: number
+          updated_at?: string | null
+        }
+        Update: {
+          user_id?: string
+          streak?: number
+          points?: number
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "habit_metrics_user_id_fkey",
+            columns: ["user_id"],
+            isOneToOne: true,
+            referencedRelation: "profiles",
+            referencedColumns: ["id"],
+          },
+        ]
+      }
       profiles: {
         Row: {
           avatar_url: string | null

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -109,6 +109,35 @@ export interface Database {
         }
         Relationships: []
       }
+      habit_metrics: {
+        Row: {
+          user_id: string
+          streak: number
+          points: number
+          updated_at: string | null
+        }
+        Insert: {
+          user_id: string
+          streak?: number
+          points?: number
+          updated_at?: string | null
+        }
+        Update: {
+          user_id?: string
+          streak?: number
+          points?: number
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "habit_metrics_user_id_fkey",
+            columns: ["user_id"],
+            isOneToOne: true,
+            referencedRelation: "profiles",
+            referencedColumns: ["id"],
+          },
+        ]
+      }
       projects: {
         Row: {
           color: string

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -3,6 +3,19 @@ import { supabase } from './supabase'
 import { Task, TaskType, ProjectType, Template, Team, UserProfile } from './types'
 import { toast } from 'sonner'
 
+const calculateMetrics = (tasks: TaskType[]) => {
+  const completed = tasks.filter(t => t.status === 'Complete')
+  const productivityScore = completed.length * 10
+  const dates = new Set(completed.map(t => new Date(t.updated_at).toDateString()))
+  let streak = 0
+  let day = new Date()
+  while (dates.has(day.toDateString())) {
+    streak++
+    day.setDate(day.getDate() - 1)
+  }
+  return { productivityScore, streak }
+}
+
 interface TaskStore {
   // State
   tasks: TaskType[]
@@ -17,6 +30,8 @@ interface TaskStore {
   pomodoroTime: number
   selectedProject: string | null
   aiSuggestion: string
+  productivityScore: number
+  streak: number
   
   // Actions
   setTasks: (tasks: TaskType[]) => void
@@ -64,9 +79,14 @@ export const useStore = create<TaskStore>((set, get) => ({
   pomodoroTime: 25 * 60,
   selectedProject: null,
   aiSuggestion: '',
+  productivityScore: 0,
+  streak: 0,
 
   // State setters
-  setTasks: (tasks) => set({ tasks }),
+  setTasks: (tasks) => {
+    const { productivityScore, streak } = calculateMetrics(tasks)
+    set({ tasks, productivityScore, streak })
+  },
   setProjects: (projects) => set({ projects }),
   setTemplates: (templates) => set({ templates }),
   setTeams: (teams) => set({ teams }),
@@ -94,7 +114,7 @@ export const useStore = create<TaskStore>((set, get) => ({
         subtasks: Array.isArray(task.subtasks) ? task.subtasks : [],
       }))
 
-      set({ tasks: tasksWithSubtasks })
+      get().setTasks(tasksWithSubtasks)
     } catch (error) {
       console.error('Error fetching tasks:', error)
       toast.error('Failed to fetch tasks')
@@ -149,8 +169,8 @@ export const useStore = create<TaskStore>((set, get) => ({
 
       if (error) throw error
 
-      const { tasks } = get()
-      set({ tasks: [...tasks, data] })
+      const { tasks, setTasks } = get()
+      setTasks([...tasks, data])
       toast.success('Task created successfully')
     } catch (error) {
       console.error('Error adding task:', error)
@@ -167,12 +187,12 @@ export const useStore = create<TaskStore>((set, get) => ({
 
       if (error) throw error
 
-      const { tasks } = get()
-      set({ 
-        tasks: tasks.map(task => 
+      const { tasks, setTasks } = get()
+      setTasks(
+        tasks.map(task =>
           task.id.toString() === taskId ? { ...task, ...updates } as TaskType : task
         )
-      })
+      )
       toast.success('Task updated successfully')
     } catch (error) {
       console.error('Error updating task:', error)
@@ -189,8 +209,8 @@ export const useStore = create<TaskStore>((set, get) => ({
 
       if (error) throw error
 
-      const { tasks } = get()
-      set({ tasks: tasks.filter(task => task.id.toString() !== taskId) })
+      const { tasks, setTasks } = get()
+      setTasks(tasks.filter(task => task.id.toString() !== taskId))
       toast.success('Task deleted successfully')
     } catch (error) {
       console.error('Error deleting task:', error)
@@ -199,27 +219,30 @@ export const useStore = create<TaskStore>((set, get) => ({
   },
 
   toggleTaskStatus: async (taskId: string) => {
-    const { tasks } = get()
+    const { tasks, setTasks } = get()
     const task = tasks.find(t => t.id.toString() === taskId)
     if (!task) return
 
     const newStatus = task.status === 'Complete' ? 'To Do' : 'Complete'
     try {
+      const updatedAt = new Date().toISOString()
       const { error } = await supabase
         .from('tasks')
-        .update({ 
+        .update({
           status: newStatus,
-          updated_at: new Date().toISOString()
+          updated_at: updatedAt
         })
         .eq('id', taskId)
 
       if (error) throw error
 
-      set({ 
-        tasks: tasks.map(t => 
-          t.id.toString() === taskId ? { ...t, status: newStatus } : t
+      setTasks(
+        tasks.map(t =>
+          t.id.toString() === taskId
+            ? { ...t, status: newStatus, updated_at: updatedAt }
+            : t
         )
-      })
+      )
       toast.success(`Task marked as ${newStatus}`)
     } catch (error) {
       console.error('Error toggling task status:', error)

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -193,6 +193,8 @@ export interface TaskType {
   subtasks?: Subtask[]
   dependencies?: string[]
   created_at: string
+  updated_at: string
+  completed_at?: string | null
 }
 
 export interface TasksProps {

--- a/supabase/database.types.ts
+++ b/supabase/database.types.ts
@@ -39,6 +39,35 @@ export type Database = {
         }
         Relationships: []
       }
+      habit_metrics: {
+        Row: {
+          user_id: string
+          streak: number
+          points: number
+          updated_at: string | null
+        }
+        Insert: {
+          user_id: string
+          streak?: number
+          points?: number
+          updated_at?: string | null
+        }
+        Update: {
+          user_id?: string
+          streak?: number
+          points?: number
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "habit_metrics_user_id_fkey",
+            columns: ["user_id"],
+            isOneToOne: true,
+            referencedRelation: "profiles",
+            referencedColumns: ["id"],
+          },
+        ]
+      }
       projects: {
         Row: {
           color: string

--- a/supabase/migrations/20240324000028_create_habit_metrics.sql
+++ b/supabase/migrations/20240324000028_create_habit_metrics.sql
@@ -1,0 +1,24 @@
+-- Create habit_metrics table to track streaks and points per user
+create table if not exists habit_metrics (
+  user_id uuid primary key references profiles(id) on delete cascade,
+  streak integer not null default 0,
+  points integer not null default 0,
+  updated_at timestamptz default now()
+);
+
+alter table habit_metrics enable row level security;
+
+create policy "Users can view their habit metrics"
+  on habit_metrics
+  for select
+  using (auth.uid() = user_id);
+
+create policy "Users can update their habit metrics"
+  on habit_metrics
+  for update
+  using (auth.uid() = user_id);
+
+create policy "Users can insert their habit metrics"
+  on habit_metrics
+  for insert
+  with check (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- add habit_metrics table for user streaks and points with RLS policies
- compute productivity score and streak in store and display on dashboard with animated badge
- test dashboard score and streak rendering

## Testing
- `pnpm lint`
- `pnpm run test` *(fails: Missing script: test)*
- `npx jest __tests__/components/dashboard.test.tsx` *(fails: Need to install the following packages: jest@30.0.5)*


------
https://chatgpt.com/codex/tasks/task_e_689ba8bef6f8832d976675d35d7dd5d0