### PR TITLE
feat: respect daily digest preference

### DIFF
--- a/__tests__/api/daily-summary.test.ts
+++ b/__tests__/api/daily-summary.test.ts
@@ -1,0 +1,41 @@
+import { POST } from '@/app/api/daily-summary/route'
+
+const mockSendEmail = jest.fn()
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn(() => Promise.resolve({
+    get: () => undefined,
+    set: () => {},
+    delete: () => {}
+  }))
+}))
+
+jest.mock('@supabase/ssr', () => ({
+  createServerClient: jest.fn(() => ({
+    auth: {
+      getUser: jest.fn().mockResolvedValue({
+        data: { user: { id: '1', email: 'test@example.com', user_metadata: { daily_digest: false } } },
+        error: null
+      })
+    }
+  }))
+}))
+
+jest.mock('@/lib/email', () => ({
+  sendEmail: mockSendEmail
+}))
+
+describe('daily summary API', () => {
+  it('skips sending email when the flag is off', async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.com'
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon'
+
+    const req = new Request('http://localhost', { method: 'POST' })
+    const res = await POST(req)
+    const json = await res.json()
+
+    expect(json.skipped).toBe(true)
+    expect(mockSendEmail).not.toHaveBeenCalled()
+  })
+})
+

--- a/app/api/daily-summary/route.ts
+++ b/app/api/daily-summary/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from 'next/server';
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+import { sendEmail } from '@/lib/email';
+
+export async function POST(req: Request) {
+  try {
+    const cookieStore = await cookies();
+
+    const supabase = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        cookies: {
+          get(name: string) {
+            const cookie = cookieStore.get(name);
+            return cookie?.value;
+          },
+          set(name: string, value: string, options: any) {
+            try {
+              cookieStore.set({ name, value, ...options });
+            } catch (error) {
+              // Handle cookie errors in development
+            }
+          },
+          remove(name: string, options: any) {
+            try {
+              cookieStore.delete({ name, ...options });
+            } catch (error) {
+              // Handle cookie errors in development
+            }
+          },
+        },
+      }
+    );
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json(
+        { error: 'Unauthorized access', details: authError?.message },
+        { status: 401 }
+      );
+    }
+
+    if (user.user_metadata?.daily_digest === false) {
+      return NextResponse.json({ skipped: true });
+    }
+
+    await sendEmail({
+      to: user.email!,
+      subject: 'Daily Summary',
+      html: '<p>Your daily summary</p>',
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add daily summary endpoint that skips sending emails when a user disabled daily digests
- test daily summary endpoint skips email when flag is off

## Testing
- `npx jest __tests__/api/daily-summary.test.ts` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_689bab0267b0832d97451a754e027aac