### PR TITLE
Skip AI suggestion when no tasks

### DIFF
--- a/__tests__/api/ai-suggestion.test.ts
+++ b/__tests__/api/ai-suggestion.test.ts
@@ -1,0 +1,55 @@
+import aiSuggestion from '@/app/api/[[...route]]/aiSuggestion';
+
+const mockCreate = jest.fn().mockResolvedValue({
+  choices: [
+    {
+      message: {
+        content: 'Use a planner',
+      },
+    },
+  ],
+});
+
+jest.mock('openai', () => {
+  return {
+    OpenAI: function () {
+      return {
+        chat: {
+          completions: {
+            create: mockCreate,
+          },
+        },
+      };
+    },
+  };
+});
+
+describe('aiSuggestion API', () => {
+  beforeEach(() => {
+    mockCreate.mockClear();
+  });
+
+  it('returns a suggestion when tasks are provided', async () => {
+    const res = await aiSuggestion.request('/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tasks: ['Task 1'] }),
+    });
+
+    const json = await res.json();
+    expect(json.suggestion).toBe('Use a planner');
+    expect(mockCreate).toHaveBeenCalled();
+  });
+
+  it('returns a message when no tasks for today', async () => {
+    const res = await aiSuggestion.request('/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tasks: [] }),
+    });
+
+    const json = await res.json();
+    expect(json.message).toBe('No tasks for today');
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/[[...route]]/aiSuggestion.ts
+++ b/app/api/[[...route]]/aiSuggestion.ts
@@ -13,6 +13,10 @@ app.post(async (c) => {
     return c.json({ error: "No tasks provided" }, 400);
   }
 
+  if (Array.isArray(tasks) && tasks.length === 0) {
+    return c.json({ message: "No tasks for today" });
+  }
+
   try {
     const prompt = `
       Analyze the following tasks and provide a suggestion to improve productivity.


### PR DESCRIPTION
## Summary
- Return message when no tasks and skip OpenAI call
- Test that empty task lists bypass AI suggestion

## Testing
- `npm run lint`
- `npx jest __tests__/api/ai-suggestion.test.ts __tests__/api/project-planner.test.ts` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_689bab03d2e8832dbdac124e801ca096