### PR TITLE
Add runtime check for OpenAI API key

### DIFF
--- a/__tests__/api/openai-env.test.js
+++ b/__tests__/api/openai-env.test.js
@@ -1,0 +1,18 @@
+describe('openai env validation', () => {
+  const originalKey = process.env.OPENAI_API_KEY
+
+  afterEach(() => {
+    if (originalKey !== undefined) {
+      process.env.OPENAI_API_KEY = originalKey
+    } else {
+      delete process.env.OPENAI_API_KEY
+    }
+    jest.resetModules()
+  })
+
+  it('throws if OPENAI_API_KEY is missing', () => {
+    delete process.env.OPENAI_API_KEY
+    jest.resetModules()
+    expect(() => require('../../lib/openai')).toThrow('OPENAI_API_KEY is not set')
+  })
+})

--- a/app/api/[[...route]]/aiSuggestion.ts
+++ b/app/api/[[...route]]/aiSuggestion.ts
@@ -1,9 +1,5 @@
 import { Hono } from "hono";
-import { OpenAI } from "openai";
-
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-});
+import openai from "@/lib/openai";
 
 const app = new Hono();
 app.post(async (c) => {

--- a/app/api/[[...route]]/parseTask.ts
+++ b/app/api/[[...route]]/parseTask.ts
@@ -1,12 +1,10 @@
 import { Hono } from "hono";
-import { OpenAI } from "openai";
+import openai from "@/lib/openai";
 import { NextResponse } from "next/server";
 
 import { z } from "zod";
 
 export const runtime = "edge";
-
-const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
 // Define the schema for request validation
 const parseTaskSchema = z.object({

--- a/app/api/[[...route]]/taskBreakdown.ts
+++ b/app/api/[[...route]]/taskBreakdown.ts
@@ -1,9 +1,5 @@
 import { Hono } from "hono";
-import { OpenAI } from "openai";
-
-const openai = new OpenAI({
-    apiKey: process.env.OPENAI_API_KEY,
-});
+import openai from "@/lib/openai";
 
 const app = new Hono()
     .post(async (c) => {

--- a/app/api/ai/generate-description/route.ts
+++ b/app/api/ai/generate-description/route.ts
@@ -1,9 +1,5 @@
-import { OpenAI } from 'openai'
 import { NextResponse } from 'next/server'
-
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY
-})
+import openai from '@/lib/openai'
 
 export async function POST(request: Request) {
   try {

--- a/app/api/ai/generate-subtasks/route.ts
+++ b/app/api/ai/generate-subtasks/route.ts
@@ -1,9 +1,5 @@
-import { OpenAI } from 'openai'
 import { NextResponse } from 'next/server'
-
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY
-})
+import openai from '@/lib/openai'
 
 export async function POST(request: Request) {
   try {

--- a/app/api/ai/project-planner/route.ts
+++ b/app/api/ai/project-planner/route.ts
@@ -1,9 +1,5 @@
-import { OpenAI } from 'openai'
 import { NextResponse } from 'next/server'
-
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY
-})
+import openai from '@/lib/openai'
 
 export async function POST(request: Request) {
   try {

--- a/app/api/task-suggestions/route.ts
+++ b/app/api/task-suggestions/route.ts
@@ -1,11 +1,7 @@
 import { NextResponse } from 'next/server';
-import OpenAI from 'openai';
+import openai from '@/lib/openai';
 import { z } from 'zod';
 import { TaskPriority, TaskStatus } from '@/lib/types';
-
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-});
 
 const requestSchema = z.object({
   input: z.string().min(1),

--- a/app/api/tools/ai/route.ts
+++ b/app/api/tools/ai/route.ts
@@ -1,10 +1,6 @@
 import { NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase-server'
-import OpenAI from 'openai'
-
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY
-})
+import openai from '@/lib/openai'
 
 export async function GET() {
   try {

--- a/app/api/vision/route.ts
+++ b/app/api/vision/route.ts
@@ -1,9 +1,5 @@
 import { NextResponse } from 'next/server'
-import OpenAI from 'openai'
-
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-})
+import openai from '@/lib/openai'
 
 export async function POST(request: Request) {
   try {

--- a/lib/ai/transcription.ts
+++ b/lib/ai/transcription.ts
@@ -1,8 +1,4 @@
-import OpenAI from 'openai'
-
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-})
+import openai from '@/lib/openai'
 
 export async function transcribeAudio(audio: Blob): Promise<string> {
   const file = new File([audio], 'audio.webm', { type: audio.type })

--- a/lib/openai.js
+++ b/lib/openai.js
@@ -1,0 +1,9 @@
+const OpenAI = require('openai')
+
+if (!process.env.OPENAI_API_KEY) {
+  throw new Error('OPENAI_API_KEY is not set')
+}
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+
+module.exports = openai


### PR DESCRIPTION
## Summary
- centralize OpenAI client with runtime OPENAI_API_KEY check
- switch API routes and transcription helper to shared client
- cover missing-key error path with unit test

## Testing
- `npx jest __tests__/api/openai-env.test.js`
- `npx jest` *(fails: SyntaxError Cannot use import statement outside a module)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bab05e9e4832dba90b0f2ad32830a