### PR TITLE
chore: exclude Supabase functions from TS build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,6 +36,7 @@
   ],
   "exclude": [
     "node_modules",
-    "supabase"
+    "supabase",
+    "supabase/functions/**"
   ]
 }


### PR DESCRIPTION
## Summary
- exclude `supabase/functions/**` from TypeScript compilation so Next.js doesn't compile Deno edge functions

## Testing
- `pnpm run build` *(fails: Failed to fetch Inter font from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689f227f0f90832dad7b4b10884902cf