### PR TITLE
docs: add jsdoc for task service

### DIFF
--- a/lib/task-service.ts
+++ b/lib/task-service.ts
@@ -15,6 +15,31 @@ async function withRetry<T>(operation: () => Promise<T>, context: string): Promi
   throw new Error(`Failed to ${context}`)
 }
 
+/**
+ * Retrieve all tasks belonging to a user from the `tasks` table.
+ *
+ * @param {string} userId - The identifier of the user whose tasks should be returned.
+ * @returns {Promise<Task[]>} Resolves with an array of tasks enriched with optional project details.
+ * @throws {Error} Throws if the tasks cannot be fetched after retrying the Supabase request.
+ *
+ * @example
+ * ```ts
+ * // The `tasks` table is expected to match the following schema:
+ * // create table tasks (
+ * //   id uuid primary key,
+ * //   user_id uuid references users(id),
+ * //   project_id uuid references projects(id),
+ * //   title text,
+ * //   description text,
+ * //   status text,
+ * //   priority text,
+ * //   due_date timestamp,
+ * //   created_at timestamp default now(),
+ * //   updated_at timestamp default now()
+ * // );
+ * const tasks = await getUserTasks('user-123');
+ * ```
+ */
 export async function getUserTasks(userId: string): Promise<Task[]> {
   const supabase = await createClient()
   return withRetry(async () => {
@@ -36,6 +61,28 @@ export async function getUserTasks(userId: string): Promise<Task[]> {
   }, 'fetch user tasks')
 }
 
+/**
+ * Fetch projects owned by a user from the `projects` table.
+ *
+ * @param {string} userId - The identifier of the user whose projects should be fetched.
+ * @returns {Promise<Project[]>} Resolves with an array of projects.
+ * @throws {Error} Throws if the projects cannot be retrieved after retrying the Supabase request.
+ *
+ * @example
+ * ```ts
+ * // The `projects` table is expected to match the following schema:
+ * // create table projects (
+ * //   id uuid primary key,
+ * //   user_id uuid references users(id),
+ * //   name text,
+ * //   color text,
+ * //   description text,
+ * //   created_at timestamp default now(),
+ * //   updated_at timestamp default now()
+ * // );
+ * const projects = await getProjects('user-123');
+ * ```
+ */
 export async function getProjects(userId: string): Promise<Project[]> {
   const supabase = await createClient()
   return withRetry(async () => {


### PR DESCRIPTION
## Summary
- document `getUserTasks` with usage example and Supabase schema reference
- document `getProjects` with usage example and Supabase schema reference

## Testing
- `pnpm lint` *(fails: tsconfig.json(40,5): ',' expected)*

------
https://chatgpt.com/codex/tasks/task_e_689f27def608832dbfb2e2321af0a2fc