### PR TITLE
test: add calendar and settings provider tests

### DIFF
--- a/__tests__/components/calendar-page-client.test.tsx
+++ b/__tests__/components/calendar-page-client.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { CalendarPageClient } from '@/components/calendar-page-client'
+import { toast } from 'sonner'
+
+// Mock CalendarView to capture props
+const calendarViewMock = jest.fn(() => null)
+jest.mock('@/components/calendar-view', () => ({
+  CalendarView: (props) => {
+    calendarViewMock(props)
+    return null
+  },
+}))
+
+// Mock the Zustand store
+const useStoreMock = jest.fn()
+const mockAddTask = jest.fn()
+const mockUpdateTask = jest.fn()
+const mockDeleteTask = jest.fn()
+const mockFetchTasks = jest.fn().mockResolvedValue(undefined)
+const mockFetchProjects = jest.fn().mockResolvedValue(undefined)
+
+jest.mock('@/store', () => ({
+  useStore: () => useStoreMock(),
+}))
+
+// Mock toast utilities
+jest.mock('sonner', () => ({
+  toast: {
+    error: jest.fn(),
+  },
+}))
+
+describe('CalendarPageClient', () => {
+  beforeEach(() => {
+    useStoreMock.mockReturnValue({
+      tasks: [],
+      projects: [],
+      isLoading: false,
+      fetchTasks: mockFetchTasks,
+      fetchProjects: mockFetchProjects,
+      addTask: mockAddTask,
+      updateTask: mockUpdateTask,
+      deleteTask: mockDeleteTask,
+    })
+    calendarViewMock.mockClear()
+    mockAddTask.mockReset()
+    mockUpdateTask.mockReset()
+    mockDeleteTask.mockReset()
+    ;(toast.error as jest.Mock).mockClear()
+  })
+
+  it('shows toast when adding a task fails', async () => {
+    mockAddTask.mockResolvedValue(null)
+    render(<CalendarPageClient />)
+    const props = calendarViewMock.mock.calls[0][0]
+    await props.onAddTask({})
+    expect(toast.error).toHaveBeenCalledWith('Failed to create task')
+  })
+
+  it('shows toast when updating a task fails', async () => {
+    mockUpdateTask.mockResolvedValue(null)
+    render(<CalendarPageClient />)
+    const props = calendarViewMock.mock.calls[0][0]
+    await props.onTaskUpdate('1', {})
+    expect(toast.error).toHaveBeenCalledWith('Failed to update task')
+  })
+
+  it('shows toast when deleting a task fails', async () => {
+    mockDeleteTask.mockRejectedValue(new Error('oops'))
+    render(<CalendarPageClient />)
+    const props = calendarViewMock.mock.calls[0][0]
+    await props.onTaskDelete('1')
+    expect(toast.error).toHaveBeenCalledWith('Failed to delete task')
+  })
+})

--- a/__tests__/components/settings-provider-wrapper.test.tsx
+++ b/__tests__/components/settings-provider-wrapper.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import SettingsProviderWrapper from '@/components/settings-provider-wrapper'
+import { useSettings } from '@/lib/contexts/settings-context'
+
+// Mock the Settings context to avoid external dependencies
+jest.mock('@/lib/contexts/settings-context', () => {
+  const React = require('react')
+  const Context = React.createContext({ value: '' })
+  const useSettings = () => React.useContext(Context)
+  const SettingsProvider = ({ children }) => (
+    <Context.Provider value={{ value: 'context works' }}>{children}</Context.Provider>
+  )
+  return { SettingsProvider, useSettings }
+})
+
+// Mock toast utilities globally
+jest.mock('sonner', () => ({
+  toast: {
+    error: jest.fn(),
+    success: jest.fn(),
+  },
+}))
+
+describe('SettingsProviderWrapper', () => {
+  it('renders children within settings context', () => {
+    const Child = () => {
+      const { value } = useSettings() as { value: string }
+      return <div>{value}</div>
+    }
+
+    render(
+      <SettingsProviderWrapper>
+        <Child />
+      </SettingsProviderWrapper>
+    )
+
+    expect(screen.getByText('context works')).toBeInTheDocument()
+  })
+})

--- a/components/calendar-page-client.tsx
+++ b/components/calendar-page-client.tsx
@@ -31,7 +31,11 @@ export function CalendarPageClient() {
   }
 
   const handleTaskDelete = async (taskId: string) => {
-    await deleteTask(taskId)
+    try {
+      await deleteTask(taskId)
+    } catch {
+      toast.error('Failed to delete task')
+    }
   }
 
   const handleAddTask = async (task: Partial<Task>) => {


### PR DESCRIPTION
## Summary
- add tests for SettingsProviderWrapper to ensure children render within context
- test CalendarPageClient toast behavior for add, update, and delete failures
- handle delete task failures with error toast

## Testing
- `npx jest __tests__/components/settings-provider-wrapper.test.tsx __tests__/components/calendar-page-client.test.tsx` *(fails: Support for the experimental syntax 'jsx' isn't currently enabled)*

------
https://chatgpt.com/codex/tasks/task_e_689f27dfc848832d865e5b5ede07c4f3