### PR TITLE
Handle failed task deletions

### DIFF
--- a/__tests__/store/tasksSlice.test.ts
+++ b/__tests__/store/tasksSlice.test.ts
@@ -1,0 +1,26 @@
+import { create } from 'zustand'
+import { vi, describe, it, expect } from 'vitest'
+import type { TasksSlice } from '../../store/tasksSlice'
+import { createTasksSlice } from '../../store/tasksSlice'
+
+var eqMock: any
+
+vi.mock('@/lib/supabase-browser', () => {
+  eqMock = vi.fn()
+  return {
+    supabase: {
+      from: () => ({
+        delete: () => ({ eq: eqMock }),
+      }),
+    },
+  }
+})
+
+describe('tasksSlice deleteTask', () => {
+  it('returns false when deletion fails', async () => {
+    eqMock.mockResolvedValueOnce({ error: new Error('fail') })
+    const useTasks = create<TasksSlice>()(createTasksSlice)
+    const result = await useTasks.getState().deleteTask('1')
+    expect(result).toBe(false)
+  })
+})

--- a/components/calendar-page-client.tsx
+++ b/components/calendar-page-client.tsx
@@ -31,7 +31,8 @@ export function CalendarPageClient() {
   }
 
   const handleTaskDelete = async (taskId: string) => {
-    await deleteTask(taskId)
+    const success = await deleteTask(taskId)
+    if (!success) toast.error('Failed to delete task')
   }
 
   const handleAddTask = async (task: Partial<Task>) => {

--- a/store/tasksSlice.ts
+++ b/store/tasksSlice.ts
@@ -8,7 +8,7 @@ export interface TasksSlice {
   fetchTasks: () => Promise<void>
   addTask: (task: Partial<Task>) => Promise<Task | null>
   updateTask: (taskId: string, updates: Partial<Task>) => Promise<Task | null>
-  deleteTask: (taskId: string) => Promise<void>
+  deleteTask: (taskId: string) => Promise<boolean>
   getTaskById: (id: string) => Task | undefined
   setTasks: (tasks: Task[] | ((prev: Task[]) => Task[])) => void
 }
@@ -80,8 +80,10 @@ export const createTasksSlice: StateCreator<TasksSlice> = (set, get) => ({
 
       if (error) throw error
       set((state) => ({ tasks: state.tasks.filter((t) => t.id !== taskId) }))
+      return true
     } catch (error) {
       console.error('Failed to delete task', error)
+      return false
     }
   },
 


### PR DESCRIPTION
## Summary
- return boolean from `deleteTask` to signal success or failure
- surface toast error on calendar page when deletion fails
- add regression test for task deletion failure

## Testing
- `npx --yes vitest run __tests__/store/tasksSlice.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689f273a7910832db2c9a1b39a67ae8f