### PR TITLE
fix: add missing comma in tsconfig exclude array

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,7 +36,7 @@
   ],
   "exclude": [
     "node_modules",
-    "__tests__"
+    "__tests__",
     "supabase",
     "supabase/functions/**"
   ]


### PR DESCRIPTION
## Summary
- fix tsconfig exclude list syntax by adding comma after `__tests__`

## Testing
- `pnpm run build` *(fails: Failed to compile. next/font error: Failed to fetch Inter from Google Fonts; Syntax Error in components/calendar-page-client.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_689f41371244832d8967b3ee7fe93391