### PR TITLE
Fix missing closing brace in calendar task delete handler

### DIFF
--- a/components/calendar-page-client.tsx
+++ b/components/calendar-page-client.tsx
@@ -38,6 +38,8 @@ export function CalendarPageClient() {
       toast.error('Failed to delete task')
     }
 
+  };
+
   const handleAddTask = async (task: Partial<Task>) => {
     const created = await addTask(task)
     if (!created) toast.error('Failed to create task')


### PR DESCRIPTION
## Summary
- Close `handleTaskDelete` function in `CalendarPageClient`
- Ensure task deletion logic finishes before adding tasks

## Testing
- `pnpm run build` *(fails: Failed to fetch font file from `fonts.gstatic.com`, Build failed because of webpack errors)*

------
https://chatgpt.com/codex/tasks/task_e_689f6034b39c832d9ba24732bb85e041